### PR TITLE
DialogConfirm.xml: Add button id "12"

### DIFF
--- a/1080i/DialogConfirm.xml
+++ b/1080i/DialogConfirm.xml
@@ -15,6 +15,14 @@
                 <align>center</align>
                 <orientation>horizontal</orientation>
                 <itemgap>30</itemgap>
+                <control type="button" id="12">
+                    <description>Extra button</description>
+                    <width>320</width>
+                    <label></label>
+                    <font>font_button</font>
+                    <texturefocus colordiffuse="$VAR[ColorHighlight]" border="5">diffuse/box.png</texturefocus>
+                    <texturenofocus colordiffuse="dialog_fg_12" border="5">diffuse/box.png</texturenofocus>
+                </control>
                 <control type="button" id="11">
                     <description>Yes</description>
                     <width>320</width>


### PR DESCRIPTION
Some addons depends on the extra button id "12" i.e. script.extendedinfo,
without this button upon opening DialogConfirm the focus isn't on any button and you can't select any option.

Tested on Kodi 18.2, everything works as expected.