### PR TITLE
add finish time to Playscreen

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -118,7 +118,7 @@
 
     <variable name="Label_OSD_Duration">
         <value condition="PVR.IsPlayingTV + !String.IsEmpty(PVR.EpgEventDuration)">$INFO[PVR.EpgEventDuration]</value>
-        <value>$INFO[Player.Duration]</value>
+        <value>$INFO[Player.Duration]$INFO[Player.FinishTime, • $LOCALIZE[31106]]</value>
     </variable>
     
     <variable name="Label_OSD_FinishTime">


### PR DESCRIPTION
You can only see the end time in the Pause menu..
with this change, see u the on the onscreen.

![screenshot000](https://user-images.githubusercontent.com/23200748/61185335-61d20f00-a658-11e9-92cb-2a4519aad215.png)
