### PR TITLE
:construction: - Add simple Landscape Poster widget

### DIFF
--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -281,7 +281,27 @@
                         <param name="labelinclude" value="$PARAM[labelinclude]" />
                     </include>
                 </focusedlayout>
-
+                
+                <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition] | $PARAM[landscapecondition]]">
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="false" />
+                        <param name="icon" value="$VAR[Image_Poster]" />
+                        <param name="id" value="$PARAM[id]" />
+                        <param name="labelinclude" value="$PARAM[labelinclude]" />
+                    </include>
+                </itemlayout>
+                <focusedlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapecondition]">
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="true" />
+                        <param name="iconheight" value="item_icon_height" />
+                        <param name="icon" value="$VAR[Image_Landscape]" />
+                        <param name="diffuse" value="diffuse/landscape-wall.png" />
+                        <param name="labelinclude" value="$PARAM[landscapelabelinclude]" />
+                        <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
+                        <param name="id" value="$PARAM[id]" />
+                    </include>
+                </focusedlayout>
+                
                 <content target="$PARAM[target]" sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" limit="$PARAM[limit]">$PARAM[content]</content>
             </control>
         </definition>

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -148,6 +148,7 @@
         <param name="squarecondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Square)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Square)]" />
         <param name="iconcondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Icon)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Icon)]" />
         <param name="landscapecondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Landscape)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Landscape)]" />
+        <param name="landscapepostercondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Landscape Poster)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Landscape Poster)]" />
         <param name="smalllandscapecondition" default="false" />
         <param name="smallsquarecondition" default="false" />
         <param name="height" default="item_row_height" />
@@ -282,7 +283,7 @@
                     </include>
                 </focusedlayout>
                 
-                <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition] | $PARAM[landscapecondition]]">
+                <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition] | $PARAM[landscapepostercondition]]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="selectbox" value="false" />
                         <param name="icon" value="$VAR[Image_Poster]" />
@@ -290,7 +291,7 @@
                         <param name="labelinclude" value="$PARAM[labelinclude]" />
                     </include>
                 </itemlayout>
-                <focusedlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapecondition]">
+                <focusedlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapepostercondition]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="selectbox" value="true" />
                         <param name="iconheight" value="item_icon_height" />

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -220,7 +220,7 @@
                     </include>
                 </focusedlayout>
 
-                <itemlayout width="item_smalllandscape_width" height="item_row_height" condition="$PARAM[smalllandscapecondition]">
+                <itemlayout width="item_smalllandscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[smalllandscapecondition]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="iconheight" value="item_smalllandscape_iconheight" />
                         <param name="selectbox" value="false" />
@@ -231,7 +231,7 @@
                         <param name="id" value="$PARAM[id]" />
                     </include>
                 </itemlayout>
-                <focusedlayout width="item_smalllandscape_width" height="item_row_height" condition="$PARAM[smalllandscapecondition]">
+                <focusedlayout width="item_smalllandscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[smalllandscapecondition]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="selectbox" value="true" />
                         <param name="iconheight" value="item_smalllandscape_iconheight" />
@@ -242,8 +242,28 @@
                         <param name="id" value="$PARAM[id]" />
                     </include>
                 </focusedlayout>
+                
+                <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition]">
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="false" />
+                        <param name="icon" value="$VAR[Image_Poster]" />
+                        <param name="id" value="$PARAM[id]" />
+                        <param name="labelinclude" value="$PARAM[labelinclude]" />
+                    </include>
+                </itemlayout>
+                <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition]">
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="true" />
+                        <param name="iconheight" value="item_icon_height" />
+                        <param name="icon" value="$VAR[Image_Landscape]" />
+                        <param name="diffuse" value="diffuse/landscape-wall.png" />
+                        <param name="labelinclude" value="$PARAM[landscapelabelinclude]" />
+                        <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
+                        <param name="id" value="$PARAM[id]" />
+                    </include>
+                </focusedlayout>
 
-                <itemlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapecondition]">
+                <itemlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapecondition]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="iconheight" value="item_icon_height" />
                         <param name="selectbox" value="false" />
@@ -254,7 +274,7 @@
                         <param name="id" value="$PARAM[id]" />
                     </include>
                 </itemlayout>
-                <focusedlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapecondition]">
+                <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapecondition]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="selectbox" value="true" />
                         <param name="iconheight" value="item_icon_height" />
@@ -280,26 +300,6 @@
                         <param name="icon" value="$VAR[Image_Poster]" />
                         <param name="id" value="$PARAM[id]" />
                         <param name="labelinclude" value="$PARAM[labelinclude]" />
-                    </include>
-                </focusedlayout>
-                
-                <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition] | $PARAM[landscapepostercondition]]">
-                    <include content="View_51_Wall_Itemlayout">
-                        <param name="selectbox" value="false" />
-                        <param name="icon" value="$VAR[Image_Poster]" />
-                        <param name="id" value="$PARAM[id]" />
-                        <param name="labelinclude" value="$PARAM[labelinclude]" />
-                    </include>
-                </itemlayout>
-                <focusedlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapepostercondition]">
-                    <include content="View_51_Wall_Itemlayout">
-                        <param name="selectbox" value="true" />
-                        <param name="iconheight" value="item_icon_height" />
-                        <param name="icon" value="$VAR[Image_Landscape]" />
-                        <param name="diffuse" value="diffuse/landscape-wall.png" />
-                        <param name="labelinclude" value="$PARAM[landscapelabelinclude]" />
-                        <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
-                        <param name="id" value="$PARAM[id]" />
                     </include>
                 </focusedlayout>
                 

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -251,7 +251,15 @@
                         <param name="labelinclude" value="$PARAM[labelinclude]" />
                     </include>
                 </itemlayout>
-                <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition]">
+                <focusedlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition] + !Control.HasFocus($PARAM[id])">
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="false" />
+                        <param name="icon" value="$VAR[Image_Poster]" />
+                        <param name="id" value="$PARAM[id]" />
+                        <param name="labelinclude" value="$PARAM[labelinclude]" />
+                    </include>
+                </focusedlayout>
+                <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition] + Control.HasFocus($PARAM[id])">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="selectbox" value="true" />
                         <param name="iconheight" value="item_icon_height" />

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -252,23 +252,33 @@
                     </include>
                 </itemlayout>
                 <focusedlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition] + !Control.HasFocus($PARAM[id])">
-                    <include content="View_51_Wall_Itemlayout">
-                        <param name="selectbox" value="false" />
-                        <param name="icon" value="$VAR[Image_Poster]" />
-                        <param name="id" value="$PARAM[id]" />
-                        <param name="labelinclude" value="$PARAM[labelinclude]" />
-                    </include>
+                    <control type="group">
+                        <animation type="Focus">
+                            <effect type="zoom" start="192, 100" end="100, 100" time="150" tween="quadratic"/>
+                        </animation>
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="false" />
+                            <param name="icon" value="$VAR[Image_Poster]" />
+                            <param name="id" value="$PARAM[id]" />
+                            <param name="labelinclude" value="$PARAM[labelinclude]" />
+                        </include>
+                    </control>
                 </focusedlayout>
                 <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapepostercondition] + Control.HasFocus($PARAM[id])">
-                    <include content="View_51_Wall_Itemlayout">
-                        <param name="selectbox" value="true" />
-                        <param name="iconheight" value="item_icon_height" />
-                        <param name="icon" value="$VAR[Image_Landscape]" />
-                        <param name="diffuse" value="diffuse/landscape-wall.png" />
-                        <param name="labelinclude" value="$PARAM[landscapelabelinclude]" />
-                        <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
-                        <param name="id" value="$PARAM[id]" />
-                    </include>
+                    <control type="group">
+                        <animation type="Focus">
+                            <effect type="zoom" start="52, 100" end="100, 100" time="150" tween="quadratic"/>
+                        </animation>
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="true" />
+                            <param name="iconheight" value="item_icon_height" />
+                            <param name="icon" value="$VAR[Image_Landscape]" />
+                            <param name="diffuse" value="diffuse/landscape-wall.png" />
+                            <param name="labelinclude" value="$PARAM[landscapelabelinclude]" />
+                            <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
+                            <param name="id" value="$PARAM[id]" />
+                        </include>
+                    </control>
                 </focusedlayout>
 
                 <itemlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[squarecondition] | $PARAM[iconcondition]] + $PARAM[landscapecondition]">

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -47,6 +47,7 @@
     <property property="widgetAspect">Landscape</property>
     <property property="widgetAspect">Small Square</property>
     <property property="widgetAspect">Small Landscape</property>
+    <property property="widgetAspect">Landscape Poster</property>
     <propertySettings property="widgetAspect" buttonID="9901" title="Widget Aspect Ratio" />
 
     <!-- Widget Target -->

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -193,6 +193,7 @@
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <include content="Defs_AutoScroll">
                     <param name="condition" value="!ControlGroup(3000).HasFocus() + System.IdleTime(1) + !Skin.HasSetting(DisableAutoScrollWidgets)" />
                 </include>
@@ -301,6 +302,7 @@
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <onback>SetFocus($PYTHON[int(mainmenuid)]3101)</onback>
                 <onback>301</onback>
                 <visible>Integer.IsGreater(Container($PYTHON[int(mainmenuid)]$PYTHON[int(id) + 3100]).NumItems,0) | Container($PYTHON[int(mainmenuid)]$PYTHON[int(id) + 3100]).IsUpdating</visible>


### PR DESCRIPTION
Hopefully this PR will be to address the widget types in #82. This **isn't** functional yet, but I'm hoping to figure out what I'm missing.

So far, I've added "Landscape Poster" to the list of widget aspects, and it is selectable. I've also added a pair of `<itemlayout>` (matching "Poster") and `<focusedlayout>` (matching "Landscape")... but changing the widget aspect to "Landscape Poster" just displays the widget as "Landscape".

Any ideas?