### PR TITLE
Added Clear Art for Video OSD

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -98,6 +98,13 @@
         <value condition="String.EndsWith(ListItem.Icon,icon.png)">$INFO[ListItem.Icon]</value>
     </variable>
 
+    <variable name="Image_Player_Clearart">
+    <value condition="!String.IsEmpty(Player.Art(tvshow.clearart))">$INFO[Player.Art(tvshow.clearart)]</value>
+    <value condition="!String.IsEmpty(Player.Art(clearart))">$INFO[Player.Art(clearart)]</value>
+    <value condition="!String.IsEmpty(Player.Art(tvshow.clearlogo))">$INFO[Player.Art(tvshow.clearlogo)]</value>
+    <value condition="!String.IsEmpty(Player.Art(clearlogo))">$INFO[Player.Art(clearlogo)]</value>
+    </variable>
+
     <variable name="Image_ClearLogo">
         <value condition="!String.IsEmpty(ListItem.Art(clearlogo))">$INFO[ListItem.Art(clearlogo)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(tvshow.clearlogo)) + !String.IsEqual(Container.ShowTitle,ListItem.TvShowTitle)">$INFO[ListItem.Art(tvshow.clearlogo)]</value>
@@ -182,7 +189,7 @@
         <value condition="!String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
         <value>$INFO[ListItem.Icon]</value>
     </variable>
-    
+
     <variable name="Image_Landscape">
         <value condition="!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))">$INFO[ListItem.Art(thumb)]</value>
         <value condition="Skin.HasSetting(SkinHelper.EnableAnimatedPosters) + !String.IsEmpty(ListItem.Art(animatedfanart))">$INFO[ListItem.Art(animatedfanart)]</value>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -641,7 +641,7 @@
                 <visible>Skin.HasSetting(ShowOSDClearArt)</visible>
                 <aspectratio>keep</aspectratio>
                 <animation effect="fade" start="0" end="100" delay="200" time="300">Visible</animation>
-            </control>            
+            </control>
 
             <!-- Small Info OSD -->
             <control type="group">
@@ -1034,15 +1034,11 @@
             <texturenofocus colordiffuse="panel_fg_70">osd/info.png</texturenofocus>
             <onclick>SetProperty(OSDExtendedInfo,1,Home)</onclick>
             <onclick condition="!Player.Paused + !Skin.HasSetting(DontPauseOSD)">Pause</onclick>
-
-            <onclick condition="String.IsEmpty(VideoPlayer.DBID) + VideoPlayer.Content(movies) + !String.IsEmpty(VideoPlayer.IMDBNumber)">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=find&amp;type=movie&amp;imdb_id=$INFO[VideoPlayer.IMDBNumber],call_id=1137,delay=0.35)</onclick>
+            <onclick condition="String.IsEmpty(VideoPlayer.DBID) + VideoPlayer.Content(movies) + !String.IsEmpty(VideoPlayer.IMDBNumber)">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=details&amp;type=movie&amp;imdb_id=$INFO[VideoPlayer.IMDBNumber],call_id=1137,delay=0.35)</onclick>
             <onclick condition="String.IsEmpty(VideoPlayer.DBID) + VideoPlayer.Content(movies) + String.IsEmpty(VideoPlayer.IMDBNumber)">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=details&amp;type=movie&amp;query=$INFO[Player.Title],call_id=1137,delay=0.35)</onclick>
             <onclick condition="String.IsEmpty(VideoPlayer.DBID) + [VideoPlayer.Content(tvshows) | VideoPlayer.Content(episodes)]">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=details&amp;type=tv&amp;query=$INFO[VideoPlayer.TvShowTitle],call_id=1137,delay=0.35)</onclick>
-
-
             <onclick condition="!String.IsEmpty(VideoPlayer.DBID) + VideoPlayer.Content(movies)">RunScript(plugin.video.themoviedb.helper,add_path=$INFO[Player.Title,videodb://movies/titles/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22title%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%5B%22,%22%5D%7D%5D%7D%2C%22type%22%3A%22movies%22%7D],call_id=1137,delay=0.35)</onclick>
             <onclick condition="!String.IsEmpty(VideoPlayer.DBID) + [VideoPlayer.Content(tvshows) | VideoPlayer.Content(episodes)]">RunScript(plugin.video.themoviedb.helper,add_path=$INFO[VideoPlayer.TvShowTitle,videodb://tvshows/titles/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22title%22%2C%22operator%22%3A%22is%22%2C%22value%22%3A%5B%22,%22%5D%7D%5D%7D%2C%22type%22%3A%22tvshows%22%7D],call_id=1137,delay=0.35)</onclick>
-
             <onfocus condition="!String.IsEmpty(Window(Home).Property(OSDExtendedInfo)) + Player.Paused + !Skin.HasSetting(DontPauseOSD)">Play</onfocus>
             <onfocus condition="!String.IsEmpty(Window(Home).Property(OSDExtendedInfo))">ClearProperty(OSDExtendedInfo,Home)</onfocus>
             <onfocus>ClearProperty(OSD_Menu,Home)</onfocus>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -83,7 +83,7 @@
                     <animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
                     <include>Animation_FadeIn</include>
                     <include>Animation_FadeOut</include>
-                    
+
                     <!-- Album Cover -->
                     <include content="OSD_Music_Info_Image_Square">
                         <param name="artwork" value="$PARAM[artwork]" />
@@ -202,12 +202,12 @@
 
     <include name="OSD_VideoPosition">
         <align>center</align>
-        <height>48</height>        
+        <height>48</height>
         <centerbottom>95</centerbottom>
     </include>
     <include name="OSD_LiveTVPosition">
         <align>center</align>
-        <height>48</height>        
+        <height>48</height>
         <centerbottom>121</centerbottom>
         <left>331</left>
         <width>723</width>
@@ -219,7 +219,7 @@
         <include condition="!Skin.HasSetting(DisableMusicOSDArtistImage) + !Skin.HasSetting(DisableMusicOSDClearLogo)">OSD_Right340</include>
         <include condition="Skin.HasSetting(DisableMusicOSDArtistImage) + !Skin.HasSetting(DisableMusicOSDClearLogo)">OSD_RightSide</include>
         <align>center</align>
-        <height>48</height>        
+        <height>48</height>
         <centerbottom>95</centerbottom>
     </include>
 
@@ -421,7 +421,7 @@
                     <texture>common/dim-gradient.png</texture>
                 </control>
 
-                
+
 
                 <control type="group" description="info">
                     <left>view_pad</left>
@@ -630,6 +630,18 @@
                     </control>
                 </control>
             </control>
+            <control type="image">
+                <bottom>150</bottom>
+                <right>view_pad</right>
+                <width>500</width>
+                <height>281</height>
+                <texture background="true">$VAR[Image_Player_Clearart]</texture>
+                <visible>![!String.IsEmpty(Window(Home).Property(OSDInfo)) | Player.ShowInfo | Window.IsActive(DialogFullScreenInfo.xml) | [Player.Paused + Skin.HasSetting(ShowInfoPaused)]]</visible>
+                <visible>!Window.IsVisible(DialogPlayerProcessInfo.xml)</visible>
+                <visible>Skin.HasSetting(ShowOSDClearArt)</visible>
+                <aspectratio>keep</aspectratio>
+                <animation effect="fade" start="0" end="100" delay="200" time="300">Visible</animation>
+            </control>            
 
             <!-- Small Info OSD -->
             <control type="group">
@@ -695,7 +707,7 @@
     </include>
 
     <include name="OSD_Progress_Text">
-        <!-- Clock -->  
+        <!-- Clock -->
         <control type="group">
             <top>30</top>
             <height>120</height>
@@ -1010,7 +1022,7 @@
             <visible>Window.IsVisible(videoosd)</visible>
             <visible>!VideoPlayer.Content(musicvideos)</visible>
         </control>
-        
+
         <control type="button" id="32">
             <centertop>50%</centertop>
             <description>extrainfo</description>
@@ -1022,7 +1034,7 @@
             <texturenofocus colordiffuse="panel_fg_70">osd/info.png</texturenofocus>
             <onclick>SetProperty(OSDExtendedInfo,1,Home)</onclick>
             <onclick condition="!Player.Paused + !Skin.HasSetting(DontPauseOSD)">Pause</onclick>
-            
+
             <onclick condition="String.IsEmpty(VideoPlayer.DBID) + VideoPlayer.Content(movies) + !String.IsEmpty(VideoPlayer.IMDBNumber)">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=find&amp;type=movie&amp;imdb_id=$INFO[VideoPlayer.IMDBNumber],call_id=1137,delay=0.35)</onclick>
             <onclick condition="String.IsEmpty(VideoPlayer.DBID) + VideoPlayer.Content(movies) + String.IsEmpty(VideoPlayer.IMDBNumber)">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=details&amp;type=movie&amp;query=$INFO[Player.Title],call_id=1137,delay=0.35)</onclick>
             <onclick condition="String.IsEmpty(VideoPlayer.DBID) + [VideoPlayer.Content(tvshows) | VideoPlayer.Content(episodes)]">RunScript(plugin.video.themoviedb.helper,add_path=plugin://plugin.video.themoviedb.helper/?info=details&amp;type=tv&amp;query=$INFO[VideoPlayer.TvShowTitle],call_id=1137,delay=0.35)</onclick>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -2,7 +2,7 @@
     <defaultcontrol always="true">300</defaultcontrol>
     <include>Defs_Settings_OnLoad</include>
     <onunload>RunScript(script.skinshortcuts,type=buildxml&amp;mainmenuID=301&amp;levels=1&amp;group=mainmenu|powermenu|searchmenu)</onunload>
-    <onunload condition="System.HasAddon(script.colorbox)">SetProperty(NINE_manual_set,"var=main,set=$INFO[Skin.String(colorbox_main)]|var=comp,set=$INFO[Skin.String(colorbox_comp)]|var=quality,set=$INFO[Skin.String(colorbox_quality)]|var=blursize,set=$INFO[Skin.String(colorbox_blursize)]|var=bitsize,set=$INFO[Skin.String(colorbox_bitsize)]|var=pixelsize,set=$INFO[Skin.String(colorbox_pixelsize)]|var=black,set=$INFO[Skin.String(colorbox_black)]|var=white,set=$INFO[Skin.String(colorbox_white)]|var=blend,set=$INFO[Skin.String(colorbox_blend)]|var=desat,set=$INFO[Skin.String(colorbox_desat)]",home)</onunload> 
+    <onunload condition="System.HasAddon(script.colorbox)">SetProperty(NINE_manual_set,"var=main,set=$INFO[Skin.String(colorbox_main)]|var=comp,set=$INFO[Skin.String(colorbox_comp)]|var=quality,set=$INFO[Skin.String(colorbox_quality)]|var=blursize,set=$INFO[Skin.String(colorbox_blursize)]|var=bitsize,set=$INFO[Skin.String(colorbox_bitsize)]|var=pixelsize,set=$INFO[Skin.String(colorbox_pixelsize)]|var=black,set=$INFO[Skin.String(colorbox_black)]|var=white,set=$INFO[Skin.String(colorbox_white)]|var=blend,set=$INFO[Skin.String(colorbox_blend)]|var=desat,set=$INFO[Skin.String(colorbox_desat)]",home)</onunload>
     <onload condition="String.IsEmpty(Window.Property(CurrentFocus))">SetProperty(CurrentFocus,$NUMBER[9001])</onload>
     <controls>
 
@@ -10,7 +10,7 @@
         <include>Defs_Settings_Background</include>
         <control type="group">
             <include>Dialog_Settings_Group</include>
-    
+
             <include content="Defs_Settings_Changer">
                 <onright>9000</onright>
             </include>
@@ -221,7 +221,7 @@
                         <onclick>Skin.ToggleSetting(DisableAutoScrollWidgets)</onclick>
                     </control>
 
-                    
+
 
                     <!-- ========== -->
                     <!-- Background -->
@@ -329,7 +329,7 @@
                         <onclick>SetProperty(Dialog.7.BuiltIn,Skin.SetString(AutoScroll,$LOCALIZE[31127]))</onclick>
                         <onclick>RunScript(script.toolbox,info=selectdialog,header=$LOCALIZE[31128])</onclick>
                     </control>
-                    
+
                     <control type="radiobutton" id="19206" description="Animate background ken burns">
                         <visible>Integer.IsEqual(Window.Property(CurrentFocus),9002)</visible>
                         <include>Defs_Settings_Button</include>
@@ -432,8 +432,8 @@
                         <onclick condition="String.IsEmpty(Skin.String(StartupPlaylist))">Skin.SetFile(StartupPlaylist,.mp4|.avi|.mkv|.xvid|.wmv|.mov|.xsp|.mp3|.wma|.flac|.m3u)</onclick>
                         <onclick condition="!String.IsEmpty(Skin.String(StartupPlaylist))">Skin.Reset(StartupPlaylist)</onclick>
                     </control>
-                    
-                    
+
+
                     <!-- ======= -->
                     <!-- Library -->
                     <!-- ======= -->
@@ -442,7 +442,7 @@
                         <include>Dialog_Standard_HintLabel</include>
                         <label>$LOCALIZE[31146]</label>
                     </control>
-                    
+
 
                     <control type="button" id="19410" description="Ratings">
                         <visible>Integer.IsEqual(Window.Property(CurrentFocus),9004)</visible>
@@ -649,7 +649,7 @@
                         <onclick>Skin.ToggleSetting(ArtistSlideshow.Animate)</onclick>
                         <enable>Skin.HasSetting(musicvis.fanartfallback) | !Skin.HasSetting(ArtistSlideShow.Disabled)</enable>
                     </control>
-                    
+
                     <control type="radiobutton" id="19515" description="Musicvideo auto info">
                         <visible>Integer.IsEqual(Window.Property(CurrentFocus),9005)</visible>
                         <include>Defs_Settings_Button</include>
@@ -797,6 +797,14 @@
                         <onclick>Skin.ToggleSetting(EnableClearlogo)</onclick>
                     </control>
 
+                    <control type="radiobutton" id="19710" description="Show clearart">
+                        <visible>Integer.IsEqual(Window.Property(CurrentFocus),9007)</visible>
+                        <include>Defs_Settings_Button</include>
+                        <label>$LOCALIZE[31434]</label>
+                        <selected>Skin.HasSetting(ShowOSDClearArt)</selected>
+                        <onclick>Skin.ToggleSetting(ShowOSDClearArt)</onclick>
+                    </control>
+
                     <control type="label" id="19782" description="LABEL">
                         <visible>Integer.IsEqual(Window.Property(CurrentFocus),9007)</visible>
                         <include>Dialog_Standard_HintLabel</include>
@@ -835,7 +843,7 @@
                         <onclick>Skin.ToggleSetting(MinimalBusyLoader)</onclick>
                     </control>
 
-                    
+
                     <!-- ============ -->
                     <!-- Dependencies -->
                     <!-- ============ -->
@@ -1080,7 +1088,7 @@
                         <label>$LOCALIZE[31034]</label>
                         <onclick>Addon.OpenSettings(script.skin.helper.skinbackup)</onclick>
                         <onclick condition="!System.HasAddon(script.skin.helper.skinbackup)">InstallAddon(script.skin.helper.skinbackup)</onclick>
-                        
+
                     </control>
                     <control type="button" id="19904" description="Reset">
                         <visible>Integer.IsEqual(Window.Property(CurrentFocus),9009)</visible>
@@ -1103,7 +1111,7 @@
                 </include>
             </control>
 
-            
+
 
         </control>
 

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1471,3 +1471,8 @@ msgstr ""
 msgctxt "#31433"
 msgid "Choose Palette"
 msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31434"
+msgid "Clear Art with Seek Bar"
+msgstr "Clear Art with Seek Bar"


### PR DESCRIPTION
I figured out how to add clear art on the video osd. I'm still new to this and this is the first time doing a pull request. I noticed on the changes that there were other changes done which I didn't do, like the spacing or tabs. I believe, I think it's done automatically and would understand the changes after the code but before, i don't understand why. Is it a setting on the github desktop or the atom editor?
Thanks.