### PR TITLE
:alien: - Add Defs_PauseAtEnd for use with FadeLabels

### DIFF
--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -13,6 +13,16 @@
     <variable name="Defs_ThemeSwitcher_StartTime">
         <value>06:00</value>
     </variable>
+    
+    <include name="Defs_PauseAtEnd_Value">
+        <pauseatend>$PARAM[time]</pauseatend>
+    </include>
+
+    <include name="Defs_PauseAtEnd">
+        <include content="Defs_AutoScroll">
+            <param name="include" value="Defs_PauseAtEnd_Value" />
+        </include>
+    </include>
 
     <include name="Defs_TimePerImage_Value">
         <timeperimage>$PARAM[time]</timeperimage>


### PR DESCRIPTION
In the process of another branch I'm working on locally, I found that the process outlined [in the Artwork Beef docs](https://rmrector.github.io/script.artwork.beef/skins/addonfreefun/#display-multiple-fanart), for using multiple fanart *without* Artwork Helper, requires the usage of a [FadeLabel](https://kodi.wiki/view/Fade_label_control) control, with timing being controlled by the `<pauseatend>` tag.

Unfortunately, that method can't easily be synced up with the setting at `Settings -> Skin Settings -> Background -> Set autoscroll and time per image`... because it uses the `Defs_TimePerImage` include, which eventually seems to "stand for" a `<timeperimage>` tag, which only works when used with a [MultiImage](https://kodi.wiki/view/MultiImage_Control) control.

The pull request ideally adds a simple definition that is also based on the setting mentioned in AZ2's Skin Settings, but uses `<pauseatend>` instead, to provide custom windows an Artwork Helper-free option of emulating the "cycling" artwork effect.

An interesting side effect is that it *could* also be used along with the already-supported MultiImage method, as they also support a pause between cycles.