### PR TITLE
Add Landscape Poster widget type

### DIFF
--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -372,7 +372,61 @@
                         <param name="id" value="$PARAM[id]" />
                     </include>
                 </focusedlayout>
-
+                
+                <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition]">
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="false" />
+                        <param name="icon" value="$VAR[Image_Poster]" />
+                        <param name="id" value="$PARAM[id]" />
+                        <param name="labelinclude" value="$PARAM[labelinclude]" />
+                    </include>
+                </itemlayout>
+                <focusedlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + !Control.HasFocus($PARAM[id])">
+                    <control type="group">
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="false" />
+                            <param name="icon" value="$VAR[Image_Poster]" />
+                            <param name="id" value="$PARAM[id]" />
+                            <param name="labelinclude" value="$PARAM[labelinclude]" />
+                        </include>
+                    </control>
+                </focusedlayout>
+                <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + Control.HasFocus($PARAM[id])">
+                    <control type="group">
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="true" />
+                            <param name="iconheight" value="item_icon_height" />
+                            <param name="icon" value="$VAR[Image_Landscape]" />
+                            <param name="diffuse" value="diffuse/landscape-wall.png" />
+                            <param name="labelinclude" value="Defs_Null" />
+                            <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
+                            <param name="id" value="$PARAM[id]" />
+                            <param name="label2" value="$PARAM[label2]" />
+                        </include>
+                        
+                        <animation type="Focus" tween="quadratic" easing="in">
+                            <effect type="zoom" center="left" start="42, 100" end="100, 100" delay="250" time="200" />
+                            <effect type="fade" start="0" end="100" delay="150" time="200" />
+                        </animation>
+                    </control>
+                    
+                    <control type="group">
+                        <width>item_poster_width</width>
+                        
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="true" />
+                            <param name="icon" value="$VAR[Image_Poster]" />
+                            <param name="id" value="$PARAM[id]" />
+                            <param name="labelinclude" value="$PARAM[labelinclude]" />
+                        </include>
+                        
+                        <animation type="Focus" tween="quadratic" easing="in">
+                            <effect type="zoom" center="left" start="100, 100" end="233, 100" delay="250" time="200" />
+                            <effect type="fade" start="100" end="0" delay="150" time="200" />
+                        </animation>
+                    </control>
+                </focusedlayout>
+                
                 <itemlayout width="item_landscape_width" height="item_row_height" condition="$PARAM[landscapecondition]">
                     <include content="View_51_Wall_Itemlayout">
                         <param name="iconheight" value="item_icon_height" />

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -389,12 +389,19 @@
                     </control>
                 </itemlayout>
                 <focusedlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + !Control.HasFocus($PARAM[id])">
-                    <include content="View_51_Wall_Itemlayout">
-                        <param name="selectbox" value="false" />
-                        <param name="icon" value="$VAR[Image_Poster]" />
-                        <param name="id" value="$PARAM[id]" />
-                        <param name="labelinclude" value="$PARAM[labelinclude]" />
-                    </include>
+                    <control type="group">
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="false" />
+                            <param name="icon" value="$VAR[Image_Poster]" />
+                            <param name="id" value="$PARAM[id]" />
+                            <param name="labelinclude" value="$PARAM[labelinclude]" />
+                        </include>
+                    
+                        <animation type="Conditional" tween="quadratic" easing="in" condition="!Control.HasFocus($PARAM[id])">
+                            <effect type="slide" end="-342.86" delay="0" time="0" />
+                            <effect type="slide" end="342.86" delay="250" time="200" />
+                        </animation>
+                    </control>
                 </focusedlayout>
                 <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + Control.HasFocus($PARAM[id])">
                     <control type="group">

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -382,14 +382,12 @@
                     </include>
                 </itemlayout>
                 <focusedlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + !Control.HasFocus($PARAM[id])">
-                    <control type="group">
-                        <include content="View_51_Wall_Itemlayout">
-                            <param name="selectbox" value="false" />
-                            <param name="icon" value="$VAR[Image_Poster]" />
-                            <param name="id" value="$PARAM[id]" />
-                            <param name="labelinclude" value="$PARAM[labelinclude]" />
-                        </include>
-                    </control>
+                    <include content="View_51_Wall_Itemlayout">
+                        <param name="selectbox" value="false" />
+                        <param name="icon" value="$VAR[Image_Poster]" />
+                        <param name="id" value="$PARAM[id]" />
+                        <param name="labelinclude" value="$PARAM[labelinclude]" />
+                    </include>
                 </focusedlayout>
                 <focusedlayout width="item_landscape_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + Control.HasFocus($PARAM[id])">
                     <control type="group">
@@ -404,7 +402,7 @@
                             <param name="label2" value="$PARAM[label2]" />
                         </include>
                         
-                        <animation type="Focus" tween="quadratic" easing="in">
+                        <animation type="Conditional" tween="quadratic" easing="in" condition="Control.HasFocus($PARAM[id])">
                             <effect type="zoom" center="left" start="42, 100" end="100, 100" delay="250" time="200" />
                             <effect type="fade" start="0" end="100" delay="150" time="200" />
                         </animation>
@@ -420,7 +418,7 @@
                             <param name="labelinclude" value="$PARAM[labelinclude]" />
                         </include>
                         
-                        <animation type="Focus" tween="quadratic" easing="in">
+                        <animation type="Conditional" tween="quadratic" easing="in" condition="Control.HasFocus($PARAM[id])">
                             <effect type="zoom" center="left" start="100, 100" end="233, 100" delay="250" time="200" />
                             <effect type="fade" start="100" end="0" delay="150" time="200" />
                         </animation>

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -374,12 +374,19 @@
                 </focusedlayout>
                 
                 <itemlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition]">
-                    <include content="View_51_Wall_Itemlayout">
-                        <param name="selectbox" value="false" />
-                        <param name="icon" value="$VAR[Image_Poster]" />
-                        <param name="id" value="$PARAM[id]" />
-                        <param name="labelinclude" value="$PARAM[labelinclude]" />
-                    </include>
+                    <control type="group">
+                        <include content="View_51_Wall_Itemlayout">
+                            <param name="selectbox" value="false" />
+                            <param name="icon" value="$VAR[Image_Poster]" />
+                            <param name="id" value="$PARAM[id]" />
+                            <param name="labelinclude" value="$PARAM[labelinclude]" />
+                        </include>
+                        
+                        <animation type="Conditional" tween="quadratic" easing="in" condition="Control.HasFocus($PARAM[id])">
+                            <effect type="slide" end="-342.86" delay="0" time="0" />
+                            <effect type="slide" end="342.86" delay="250" time="200" />
+                        </animation>
+                    </control>
                 </itemlayout>
                 <focusedlayout width="item_poster_width" height="item_row_height" condition="![$PARAM[iconcondition] | $PARAM[squarecondition]] + $PARAM[landscapepostercondition] + !Control.HasFocus($PARAM[id])">
                     <include content="View_51_Wall_Itemlayout">

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -267,6 +267,7 @@
         <param name="squarecondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Square)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Square)]" />
         <param name="iconcondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Icon)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Icon)]" />
         <param name="landscapecondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Landscape)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Landscape)]" />
+        <param name="landscapepostercondition" default="[!String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(302).ListItem.Property(widgetAspect),Landscape Poster)] | [String.IsEmpty(Container(302).ListItem.Property(widgetPath)) + String.IsEqual(Container(301).ListItem.Property(widgetAspect),Landscape Poster)]" />
         <param name="smalllandscapecondition" default="false" />
         <param name="smallsquarecondition" default="false" />
         <param name="bannercondition" default="false" />

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -48,6 +48,7 @@
     <property property="widgetAspect">Banner</property>
     <property property="widgetAspect">Small Square</property>
     <property property="widgetAspect">Small Landscape</property>
+    <property property="widgetAspect">Landscape Poster</property>
     <propertySettings property="widgetAspect" buttonID="9901" title="Widget Aspect Ratio" />
 
     <!-- Widget Target -->

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -137,6 +137,7 @@
                     <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                     <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                     <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                    <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                     <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                     <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 </include>
@@ -175,6 +176,7 @@
                 <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                 <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 <include content="Defs_AutoScroll">
@@ -203,6 +205,7 @@
                 <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                 <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 <include content="Defs_AutoScroll">
@@ -313,6 +316,7 @@
                 <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                 <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 <onback>SetFocus($PYTHON[int(mainmenuid)]3101)</onback>
@@ -344,6 +348,7 @@
                 <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                 <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 <onback>SetFocus($PYTHON[int(mainmenuid)]3101)</onback>
@@ -441,6 +446,7 @@
                 <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                 <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 <visible>String.IsEqual(Container(301).ListItem.Property(submenuVisibility),num-$SKINSHORTCUTS[submenuVisibility]) | String.IsEqual(Container(301).ListItem.Property(submenuVisibility),$SKINSHORTCUTS[submenuVisibility])</visible>
@@ -470,6 +476,7 @@
                 <param name="squarecondition" value="$PYTHON['true' if widgetAspect in 'Square' else 'false']" />
                 <param name="smalllandscapecondition" value="$PYTHON['true' if widgetAspect in 'Small Landscape' else 'false']" />
                 <param name="landscapecondition" value="$PYTHON['true' if widgetAspect in 'Landscape' else 'false']" />
+                <param name="landscapepostercondition" value="$PYTHON['true' if widgetAspect in 'Landscape Poster' else 'false']" />
                 <param name="iconcondition" value="$PYTHON['true' if widgetAspect in 'Icon' else 'false']" />
                 <param name="bannercondition" value="$PYTHON['true' if widgetAspect in 'Banner' else 'false']" />
                 <skinshortcuts>visibility</skinshortcuts>


### PR DESCRIPTION
I'm back at it trying to get this "Landscape Poster" widget working nicely...

And I think I've *almost* got it! It appears to work pretty well in both [Fixed](https://i.imgur.com/FBAPLWx.mp4) and [Default](https://i.imgur.com/p7aLlym.mp4), but there does seem to be a bit of "jumping around" whenever the list has to scroll more items *onto* the screen, *from the left*. I considered various combinations of `Unfocus` and `Conditional` animations to try and get it working smoothly, but I did finally get the transition from Poster to Landscape working much more smoothly, so I think this may be about as good as the animation gets.

Aside from that (which I'll gladly touch up if you have an ideas), the only other issue I was getting hung up on is shown in [this clip](https://i.imgur.com/WwChetu.mp4). When changing between items in the widget, the animations run smoothly... but whenever the widget is focused for the first time, they don't run at all. How can I get this to work correctly?