### PR TITLE
Display the playback speed in the Player OSD if it's not 1x

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -412,7 +412,7 @@
         <value condition="Player.Seeking + String.IsEmpty(Player.SeekOffset)">$LOCALIZE[773]$INFO[Player.SeekStepSize, ,]</value>
         <value condition="Player.Caching">$LOCALIZE[439] $INFO[Player.CacheLevel,,%]</value>
         <value condition="Player.Paused">$LOCALIZE[112]</value>
-        <value condition="Player.IsTempo">$LOCALIZE[31236] : $INFO[Player.PlaySpeed]x</value>
+        <value condition="Player.IsTempo">$LOCALIZE[31236] $INFO[Player.PlaySpeed]x</value>
         <value condition="Player.Playing">$LOCALIZE[31236]</value>
         <!-- <value>$INFO[System.Time,Time  ,]$INFO[Player.FinishTime,[COLOR=main_fg_70]  •  $LOCALIZE[31106] ,[/COLOR]]</value> -->
     </variable>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -412,6 +412,7 @@
         <value condition="Player.Seeking + String.IsEmpty(Player.SeekOffset)">$LOCALIZE[773]$INFO[Player.SeekStepSize, ,]</value>
         <value condition="Player.Caching">$LOCALIZE[439] $INFO[Player.CacheLevel,,%]</value>
         <value condition="Player.Paused">$LOCALIZE[112]</value>
+        <value condition="Player.IsTempo">$LOCALIZE[31236] : $INFO[Player.PlaySpeed]x</value>
         <value condition="Player.Playing">$LOCALIZE[31236]</value>
         <!-- <value>$INFO[System.Time,Time  ,]$INFO[Player.FinishTime,[COLOR=main_fg_70]  •  $LOCALIZE[31106] ,[/COLOR]]</value> -->
     </variable>


### PR DESCRIPTION
Small PR adding a value to the Label_PlayerStatus : 

Since a user can change the playback speed with ALT+LEFT/RIGHT, it is useful to display it if it's not 1x. 
Previously, the user would have no way to know the current playback speed (AFAIK).

![image](https://user-images.githubusercontent.com/15179425/69905633-e7135180-13b6-11ea-99dc-89e5594ff403.png)

I'm not quite sure there should be a " : " in the string, maybe it's better without ?