### PR TITLE
Add audio switch and language indicators to video OSD

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -60,6 +60,11 @@
             <size>16</size>
         </font>
         <font>
+            <name>font_osd_lang</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>10</size>
+        </font>
+        <font>
             <name>font_statusbar_bold</name>
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>22</size>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 
+    <variable name="OSD_CurrentSubLang">
+        <value condition="VideoPlayer.SubtitlesEnabled">$INFO[VideoPlayer.SubtitlesLanguage,[UPPERCASE],[/UPPERCASE]]</value>
+        <value></value>
+    </variable>
+
     <include name="OSD_LeftSide"><left>view_pad</left></include>
     <include name="OSD_RightSide"><right>view_pad</right></include>
     <include name="OSD_Right340"><right>340</right></include>
@@ -1021,8 +1026,14 @@
             <description>Subs</description>
             <width>48</width>
             <height>48</height>
-            <label/>
-            <font/>
+            <label>$VAR[OSD_CurrentSubLang]</label>
+            <textcolor>Selected</textcolor>
+            <focusedcolor>Highlight</focusedcolor>
+            <shadowcolor>Shadow</shadowcolor>
+            <font>font_osd_lang</font>
+            <align>right</align>
+            <aligny>top</aligny>
+            <textoffsetx>0</textoffsetx>
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/subs.png</texturefocus>
             <texturenofocus colordiffuse="panel_fg_70">osd/subs.png</texturenofocus>
             <onclick condition="Skin.HasSetting(OSDSubtitleSettings)">ActivateWindow(osdsubtitlesettings)</onclick>
@@ -1032,6 +1043,25 @@
             <onfocus condition="!String.IsEmpty(Window(Home).Property(OSDExtendedInfo)) + Player.Paused + !Skin.HasSetting(DontPauseOSD)">Play</onfocus>
             <onfocus condition="!String.IsEmpty(Window(Home).Property(OSDExtendedInfo))">ClearProperty(OSDExtendedInfo,Home)</onfocus>
             <onfocus>ClearProperty(OSD_Menu,Home)</onfocus>
+            <visible>Window.IsVisible(videoosd)</visible>
+            <visible>!VideoPlayer.Content(musicvideos)</visible>
+        </control>
+        <control type="button" id="10018">
+            <centertop>50%</centertop>
+            <description>Audio</description>
+            <width>48</width>
+            <height>48</height>
+            <label>$INFO[VideoPlayer.AudioLanguage,[UPPERCASE],[/UPPERCASE]]</label>
+            <textcolor>Selected</textcolor>
+            <focusedcolor>Highlight</focusedcolor>
+            <shadowcolor>Shadow</shadowcolor>
+            <font>font_osd_lang</font>
+            <align>right</align>
+            <aligny>top</aligny>
+            <textoffsetx>0</textoffsetx>
+            <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/audio-settings.png</texturefocus>
+            <texturenofocus colordiffuse="panel_fg_70">osd/audio-settings.png</texturenofocus>
+            <onclick>AudioNextLanguage</onclick>
             <visible>Window.IsVisible(videoosd)</visible>
             <visible>!VideoPlayer.Content(musicvideos)</visible>
         </control>


### PR DESCRIPTION
Add OSD button to switch audio channels and language indicators for selected subtitles and audio stream.

This allows users to switch audio stream without having to go to menu and to see what subtitles are enabled without waiting for the first line to appear.

I was using (fuse)neue before and I miss these features in Leia skins.