### PR TITLE
Bug fix: Hide snap when trailer is playing. 

### DIFF
--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -52,6 +52,7 @@
                     <control type="image">
                         <texture diffuse="diffuse/landscape-mediainfo.png" background="true">$VAR[ROM_Simple_Art_Snap]</texture>
                         <aspectratio scalediffuse="false">keep</aspectratio>
+                        <visible>!Player.Playing</visible>
                     </control>
                     <control type="videowindow">
                         <visible>Player.Playing + !IsEmpty(ListItem.Trailer)</visible>


### PR DESCRIPTION
Small change. Just hides the snap when trailers are playing. Snaps that are wider than the gameplay trailers are still visible when the trailer plays. Seems like the previous trailer fix just hides the background, but not the image itself