### PR TITLE
Advanced Emulator Launcher Platform Icon add and Artwork Fixes

### DIFF
--- a/1080i/Includes_AEL.xml
+++ b/1080i/Includes_AEL.xml
@@ -6,6 +6,11 @@
         <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(flyer))">$INFO[ListItem.Art(flyer)]</value>
         <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
     </variable>
+    <variable name="ROM_Simple_Art_Main_2D">
+        <value condition="!String.IsEqual(ListItem.Property(platform),MAME) + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
+        <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(flyer))">$INFO[ListItem.Art(flyer)]</value>
+        <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
+    </variable>
     <variable name="ROM_Simple_Art_Snap">
         <value condition="!String.IsEmpty(ListItem.Art(snap))">$INFO[ListItem.Art(snap)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(cartridge))">$INFO[ListItem.Art(cartridge)]</value>

--- a/1080i/Includes_AEL.xml
+++ b/1080i/Includes_AEL.xml
@@ -10,6 +10,8 @@
         <value condition="!String.IsEqual(ListItem.Property(platform),MAME) + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
         <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(flyer))">$INFO[ListItem.Art(flyer)]</value>
         <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
+        <value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
+        <value>$INFO[ListItem.Icon]</value>
     </variable>
     <variable name="ROM_Simple_Art_Snap">
         <value condition="!String.IsEmpty(ListItem.Art(snap))">$INFO[ListItem.Art(snap)]</value>

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -179,6 +179,7 @@
     <variable name="Image_Poster">
         <value condition="Skin.HasSetting(SkinHelper.EnableAnimatedPosters) + !String.IsEmpty(ListItem.Art(animatedposter))">$INFO[ListItem.Art(animatedposter)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(season.poster)) + !Window.IsVisible(Home)">$INFO[ListItem.Art(season.poster)]</value>
+        <value condition="$EXP[Exp_IsPluginAdvancedLauncher]">$VAR[ROM_Simple_Art_Main_2D]</value>
         <value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(tvshow.poster)]</value>
         <value>$INFO[ListItem.Icon]</value>
@@ -192,6 +193,7 @@
     
     <variable name="Image_Landscape">
         <value condition="!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))">$INFO[ListItem.Art(thumb)]</value>
+        <value condition="!String.IsEmpty(ListItem.Art(snap))">$INFO[ListItem.Art(snap)]</value>
         <value condition="Skin.HasSetting(SkinHelper.EnableAnimatedPosters) + !String.IsEmpty(ListItem.Art(animatedfanart))">$INFO[ListItem.Art(animatedfanart)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(landscape)) + Skin.HasSetting(LandscapeArt)">$INFO[ListItem.Art(landscape)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(tvshow.landscape)) + Skin.HasSetting(LandscapeArt)">$INFO[ListItem.Art(tvshow.landscape)]</value>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <includes>
     <include name="View_52_Showcase_Header">
         <param name="itemgap" default="10" />
@@ -78,6 +78,8 @@
                     <param name="oscar_prop" value="Window(Home).Property(ListItemHelper.awards)" />
                 </include>
             </control>
+            <!-- Advanced Emulator Launcher Specific Platform Icon -->
+            <include>View_540_Platform_Icon</include>
         </definition>
     </include>
 
@@ -214,7 +216,7 @@
             </include>
         </control>
     </include>
-    
+
     <include name="View_52_Showcase">
         <control type="group">
             <include>View_Group</include>
@@ -255,7 +257,6 @@
             <include condition="Skin.HasSetting(UseAuraShowcase)">View_52_Showcase_Aura_Info</include>
         </control>
     </include>
-
 
 
     <include name="View_520_Showcase_Square">
@@ -365,7 +366,7 @@
         <control type="group">
             <include>View_Group</include>
             <visible>Control.IsVisible(522)</visible>
-                
+
             <include content="View_51_Wall_Container">
                 <param name="id" value="522" />
                 <param name="height" value="item_row_height" />
@@ -430,7 +431,7 @@
         <control type="group">
             <include>View_Group</include>
             <visible>Control.IsVisible(524)</visible>
-            
+
             <control type="group">
                 <right>761.44</right>
                 <include content="View_51_Wall_Container">
@@ -564,7 +565,7 @@
                     <include>Object_DefaultIcon</include>
                 </control>
             </control>
-            <control type="wraplist" id="523" >
+            <control type="wraplist" id="523">
                 <viewtype label="$LOCALIZE[31231]">bigwrap</viewtype>
                 <include content="View_Forced">
                     <param name="string" value="$LOCALIZE[31231]" />
@@ -612,4 +613,3 @@
     </include>
 
 </includes>
-

--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <includes>
+    <include name="View_540_Platform_Icon">
+        <param name="top" default="0" />
+        <param name="right" default="0" />
+        <definition>
+            <control type="image">
+                <right>$PARAM[top]</right>
+                <top>$PARAM[right]</top>
+                <width>90</width>
+                <height>90</height>
+                <texture>$INFO[ListItem.Property(platform),special://home/addons/plugin.program.advanced.emulator.launcher/media/p_pixel/,.png]</texture>
+                <aspectratio>keep</aspectratio>
+            </control>
+        </definition>
+    </include>
     <include name="View_540_Button_Include">
         <control type="button">
             <left>0</left>
@@ -66,14 +80,7 @@
                 <usecontrolcoords>true</usecontrolcoords>
                 <itemgap>0</itemgap>
                 <!-- Platform Image -->
-                <control type="image">
-                    <right>0</right>
-                    <top>0</top>
-                    <width>90</width>
-                    <height>90</height>
-                    <texture>$INFO[ListItem.Property(platform),special://home/addons/plugin.program.advanced.emulator.launcher/media/p_pixel/,.png]</texture>
-                    <aspectratio>keep</aspectratio>
-                </control>
+                <include>View_540_Platform_Icon</include>
                 <!-- Title -->
                 <control type="label">
                     <top>-90</top>


### PR DESCRIPTION
Adding the platform icon to the showcase view for Advanced Emulator Launcher. Also, including artwork path fixes that didn't match up well for other views. For example, game snaps/screenshots were not getting picked up. Included some screenshots.

**Before:**
![before](https://user-images.githubusercontent.com/2657771/72225751-06290580-3557-11ea-9400-9b73a47273a8.png)

**After:**
![after1](https://user-images.githubusercontent.com/2657771/72225752-088b5f80-3557-11ea-8be1-3cae251ad191.png)
![after2](https://user-images.githubusercontent.com/2657771/72225753-0a552300-3557-11ea-803a-b6fe2f4f6369.png)

**Fixed:**
![fixed](https://user-images.githubusercontent.com/2657771/72225754-0cb77d00-3557-11ea-910f-45b0b7e06f59.png)
