### PR TITLE
Remove *stretch* from Icon Wall view. Looks odd in Advanced Emulator Launcher

### DIFF
--- a/1080i/Includes_View_51_Wall.xml
+++ b/1080i/Includes_View_51_Wall.xml
@@ -274,7 +274,7 @@
         <param name="labelinclude" default="View_512_Wall_Label" />
         <param name="aspectratio" default="scale" />
         <param name="diffuse" default="diffuse/poster-wall.png" /> <!-- FIX ME -->
-        <param name="stretchsides" default="Control.IsVisible(512) + !Window.IsVisible(home)" />
+        <param name="stretchsides" default="Control.IsVisible(512) + !Window.IsVisible(home) + !$EXP[Exp_IsPluginAdvancedLauncher]" />
         <definition>
             <control type="group">
                 <right>10</right>

--- a/1080i/MyPrograms.xml
+++ b/1080i/MyPrograms.xml
@@ -4,7 +4,7 @@
     <defaultcontrol always="true">50</defaultcontrol>
     <menucontrol>300</menucontrol>
     
-    <views>50,500,501,502,504,503,51,510,511,513,514,515,52,520,521,522,524,53,523,540</views>
+    <views>50,500,501,502,504,503,51,510,511,512,513,514,515,52,520,521,522,524,53,523,540</views>
     
     <controls>
         <include>Global_Background</include>
@@ -21,6 +21,7 @@
             <include>View_51_Wall</include>
             <include>View_510_Wall_Square</include>
             <include>View_511_Wall_Landscape</include>
+            <include>View_512_Wall_Icons</include>
             <include>View_513_Wall_Circle</include>
             <include>View_514_Wall_Info</include>
             <include>View_515_Wall_Landscape_Small</include>

--- a/1080i/MyPrograms.xml
+++ b/1080i/MyPrograms.xml
@@ -4,7 +4,7 @@
     <defaultcontrol always="true">50</defaultcontrol>
     <menucontrol>300</menucontrol>
     
-    <views>50,500,501,502,504,503,51,510,511,512,513,514,515,52,520,521,522,524,53,523,540</views>
+    <views>50,500,501,502,504,503,51,510,511,513,514,515,52,520,521,522,524,53,523,540</views>
     
     <controls>
         <include>Global_Background</include>
@@ -21,7 +21,6 @@
             <include>View_51_Wall</include>
             <include>View_510_Wall_Square</include>
             <include>View_511_Wall_Landscape</include>
-            <include>View_512_Wall_Icons</include>
             <include>View_513_Wall_Circle</include>
             <include>View_514_Wall_Info</include>
             <include>View_515_Wall_Landscape_Small</include>


### PR DESCRIPTION
Not sure about this one because I do not know how this view is intended to look. Maybe not the best way to remove, but I took the **Icon Wall** view out of Advanced Emulator Launcher.  See the screenshots below.
![screenshot1](https://user-images.githubusercontent.com/2657771/73012560-96cbd500-3de4-11ea-91ba-2f53619415c6.png)
![screenshot2](https://user-images.githubusercontent.com/2657771/73012563-96cbd500-3de4-11ea-9325-851cacbc3d35.png)
![screenshot3](https://user-images.githubusercontent.com/2657771/73012565-96cbd500-3de4-11ea-8d67-7e9cf921b32e.png)
