### PR TITLE
Add Advanced Emulator Launcher Platform Icon and ROM Details to Views

### DIFF
--- a/1080i/Includes_View_50_List.xml
+++ b/1080i/Includes_View_50_List.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <includes>
     <include name="View_50_List">
         <control type="group">
@@ -359,32 +359,40 @@
                     <aspectratio align="right" aligny="bottom">keep</aspectratio>
                     <visible>[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
                 </control>
-                <control type="grouplist">
-                    <top>377</top>
-                    <left>0</left>
-                    <right>30</right>
-                    <orientation>vertical</orientation>
-                    <usecontrolcoords>true</usecontrolcoords>
-                    <itemgap>0</itemgap>
-                    <control type="label">
-                        <font>font_title_small</font>
-                        <textcolor>main_fg_100</textcolor>
-                        <align>left</align>
-                        <aligny>top</aligny>
-                        <height>50</height>
-                        <label>$PARAM[title]</label>
-                    </control>
-                    <include content="Object_Info_Line">
-                        <param name="nextaired" value="false" />
+                <control type="group">
+                    <include content="View_540_Platform_Icon">
+                        <param name="top" value="372" />
+                        <param name="right" value="30" />
                     </include>
-                    <control type="textbox">
-                        <top>25</top>
-                        <font>font_plotbox</font>
-                        <textcolor>main_fg_70</textcolor>
-                        <align>left</align>
-                        <aligny>top</aligny>
-                        <height>320</height>
-                        <label>$PARAM[plot]</label>
+                    <control type="grouplist">
+                        <top>377</top>
+                        <left>0</left>
+                        <right>30</right>
+                        <orientation>vertical</orientation>
+                        <usecontrolcoords>true</usecontrolcoords>
+                        <itemgap>0</itemgap>
+                        <control type="label">
+                            <font>font_title_small</font>
+                            <textcolor>main_fg_100</textcolor>
+                            <align>left</align>
+                            <aligny>top</aligny>
+                            <height>50</height>
+                            <width>500</width>
+                            <label>$PARAM[title]</label>
+                        </control>
+                        <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]" content="Object_Info_Line">
+                            <param name="nextaired" value="false" />
+                        </include>
+                        <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                        <control type="textbox">
+                            <top>25</top>
+                            <font>font_plotbox</font>
+                            <textcolor>main_fg_70</textcolor>
+                            <align>left</align>
+                            <aligny>top</aligny>
+                            <height>320</height>
+                            <label>$PARAM[plot]</label>
+                        </control>
                     </control>
                 </control>
             </control>
@@ -422,36 +430,43 @@
                     <visible>[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
                 </control>
             </control>
-            <control type="grouplist">
-                <top>430</top>
-                <left>0</left>
-                <right>30</right>
-                <orientation>vertical</orientation>
-                <usecontrolcoords>true</usecontrolcoords>
-                <itemgap>0</itemgap>
-                <control type="label">
-                    <font>font_title_small</font>
-                    <textcolor>main_fg_100</textcolor>
-                    <align>left</align>
-                    <aligny>top</aligny>
-                    <height>52</height>
-                    <label>$VAR[Label_List_Title]</label>
-                </control>
-                <include>Object_Info_Line</include>
-                <include content="Object_Info_Ratings">
-                    <param name="top" value="-10" />
-                    <param name="imdbvotes" value="false" />
-                    <param name="top250" value="false" />
-                    <param name="oscars" value="false" />
+            <control type="group">
+                <include content="View_540_Platform_Icon">
+                    <param name="top" value="440" />
+                    <param name="right" value="30" />
                 </include>
-                <control type="textbox">
-                    <top>25</top>
-                    <font>font_plotbox</font>
-                    <textcolor>main_fg_70</textcolor>
-                    <align>left</align>
-                    <aligny>top</aligny>
-                    <height>160</height>
-                    <label>$VAR[Label_Plot]</label>
+                <control type="grouplist">
+                    <top>430</top>
+                    <left>0</left>
+                    <right>30</right>
+                    <orientation>vertical</orientation>
+                    <usecontrolcoords>true</usecontrolcoords>
+                    <itemgap>0</itemgap>
+                    <control type="label">
+                        <font>font_title_small</font>
+                        <textcolor>main_fg_100</textcolor>
+                        <align>left</align>
+                        <aligny>top</aligny>
+                        <height>52</height>
+                        <label>$VAR[Label_List_Title]</label>
+                    </control>
+                    <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
+                    <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                    <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
+                        <param name="top" value="-10" />
+                        <param name="imdbvotes" value="false" />
+                        <param name="top250" value="false" />
+                        <param name="oscars" value="false" />
+                    </include>
+                    <control type="textbox">
+                        <top>25</top>
+                        <font>font_plotbox</font>
+                        <textcolor>main_fg_70</textcolor>
+                        <align>left</align>
+                        <aligny>top</aligny>
+                        <height>160</height>
+                        <label>$VAR[Label_Plot]</label>
+                    </control>
                 </control>
             </control>
         </control>
@@ -554,7 +569,7 @@
                     <width>32</width>
                     <height>32</height>
                     <texture colordiffuse="$PARAM[fgcolor]_90">$VAR[Image_Overlay_List]</texture>
-                </control>                
+                </control>
                 <control type="label">
                     <animation effect="slide" end="-40" condition="!String.IsEqual(ListItem.DBType,episode)">Conditional</animation>
                     <animation effect="slide" end="-30" condition="String.IsEqual(ListItem.DBType,episode) + !Integer.IsGreater(ListItem.Season,999)">Conditional</animation>
@@ -599,7 +614,8 @@
                     <font>font_small_bold</font>
                     <textcolor>$PARAM[fgcolor]_100</textcolor>
                     <selectedcolor>$PARAM[fgcolor]_100</selectedcolor>
-                    <label>$VAR[Label_List_Title]</label>>
+                    <label>$VAR[Label_List_Title]</label>
+                    >
                 </control>
                 <control type="label">
                     <align>right</align>
@@ -1007,4 +1023,3 @@
         </definition>
     </include>
 </includes>
-

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -108,37 +108,46 @@
                     <aspectratio align="right" aligny="bottom">keep</aspectratio>
                     <visible>[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
                 </control>
-                <control type="grouplist">
-                    <top>451.435</top>
-                    <left>0</left>
-                    <right>30</right>
-                    <orientation>vertical</orientation>
-                    <usecontrolcoords>true</usecontrolcoords>
-                    <itemgap>0</itemgap>
-                    <control type="label">
-                        <font>font_title_small</font>
-                        <textcolor>main_fg_100</textcolor>
-                        <align>left</align>
-                        <aligny>top</aligny>
-                        <height>50</height>
-                        <label>$PARAM[title]</label>
-                    </control>
-                    <include condition="$PARAM[seasons]" content="Object_Info_Line">
-                        <param name="nextaired" value="false" />
+                <control type="group">
+                    <include content="View_540_Platform_Icon">
+                        <param name="top" value="440" />
+                        <param name="right" value="30" />>
                     </include>
-                    <include condition="!$PARAM[seasons]" content="Object_Info_Line">
-                        <param name="nextaired" value="false" />
-                        <param name="label" value="$INFO[Container($PARAM[id]).ListItem.MPAA]" />
-                        <param name="container" value="Container($PARAM[id])." />
-                    </include>
-                    <control type="textbox">
-                        <top>25</top>
-                        <font>font_plotbox</font>
-                        <textcolor>main_fg_70</textcolor>
-                        <align>left</align>
-                        <aligny>top</aligny>
-                        <height>200</height>
-                        <label>$PARAM[plot]</label>
+                    <control type="grouplist">
+                        <top>451.435</top>
+                        <left>0</left>
+                        <right>30</right>
+                        <orientation>vertical</orientation>
+                        <usecontrolcoords>true</usecontrolcoords>
+                        <itemgap>0</itemgap>
+                        <control type="label">
+                            <font>font_title_small</font>
+                            <textcolor>main_fg_100</textcolor>
+                            <align>left</align>
+                            <aligny>top</aligny>
+                            <height>50</height>
+                            <width>630</width>
+                            <label>$PARAM[title]</label>
+                        </control>
+                        <include condition="$EXP[Exp_IsPluginAdvancedLauncher]" content="View_540_ROM_Details">
+                        </include>
+                        <include condition="$PARAM[seasons] + !$EXP[Exp_IsPluginAdvancedLauncher]" content="Object_Info_Line">
+                            <param name="nextaired" value="false" />
+                        </include>
+                        <include condition="!$PARAM[seasons] + !$EXP[Exp_IsPluginAdvancedLauncher]" content="Object_Info_Line">
+                            <param name="nextaired" value="false" />
+                            <param name="label" value="$INFO[Container($PARAM[id]).ListItem.MPAA]" />
+                            <param name="container" value="Container($PARAM[id])." />
+                        </include>
+                        <control type="textbox">
+                            <top>25</top>
+                            <font>font_plotbox</font>
+                            <textcolor>main_fg_70</textcolor>
+                            <align>left</align>
+                            <aligny>top</aligny>
+                            <height>200</height>
+                            <label>$PARAM[plot]</label>
+                        </control>
                     </control>
                 </control>
             </control>

--- a/1080i/Includes_View_53_Poster.xml
+++ b/1080i/Includes_View_53_Poster.xml
@@ -5,29 +5,36 @@
             <visible>Control.IsVisible(53)</visible>
             <include>Defs_InfoDialog_Visible</include>
             <include>Animation_Common</include>
-            <control type="grouplist">
-                <visible>!ListItem.IsParentFolder</visible>
-                <left>660</left>
-                <top>690</top>
-                <right>view_pad</right>
-                <orientation>vertical</orientation>
-                <usecontrolcoords>true</usecontrolcoords>
-                <itemgap>0</itemgap>
-                <control type="label">
-                    <label>$VAR[Label_List_Title]</label>>
-                    <height>60</height>
-                    <aligny>top</aligny>
-                    <textcolor>main_fg_100</textcolor>
-                    <font>font_title</font>
-                </control>
-                <include>Object_Info_Line</include>
-                <control type="textbox">
-                    <top>20</top>
-                    <label fallback="19055">$VAR[Label_Plot]</label>
-                    <height>120</height>
-                    <aligny>top</aligny>
-                    <textcolor>main_fg_70</textcolor>
-                    <font>font_plotbox</font>
+            <control type="group">
+                <include content="View_540_Platform_Icon">
+                    <param name="top" value="690" />
+                    <param name="right" value="80" />
+                </include>
+                <control type="grouplist">
+                    <visible>!ListItem.IsParentFolder</visible>
+                    <left>660</left>
+                    <top>690</top>
+                    <right>view_pad</right>
+                    <orientation>vertical</orientation>
+                    <usecontrolcoords>true</usecontrolcoords>
+                    <itemgap>0</itemgap>
+                    <control type="label">
+                        <label>$VAR[Label_List_Title]</label>>
+                        <height>60</height>
+                        <aligny>top</aligny>
+                        <textcolor>main_fg_100</textcolor>
+                        <font>font_title</font>
+                    </control>
+                    <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
+                    <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                    <control type="textbox">
+                        <top>20</top>
+                        <label fallback="19055">$VAR[Label_Plot]</label>
+                        <height>120</height>
+                        <aligny>top</aligny>
+                        <textcolor>main_fg_70</textcolor>
+                        <font>font_plotbox</font>
+                    </control>
                 </control>
             </control>
             

--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -5,12 +5,27 @@
         <param name="right" default="0" />
         <definition>
             <control type="image">
-                <right>$PARAM[top]</right>
-                <top>$PARAM[right]</top>
+                <right>$PARAM[right]</right>
+                <top>$PARAM[top]</top>
                 <width>90</width>
                 <height>90</height>
                 <texture>$INFO[ListItem.Property(platform),special://home/addons/plugin.program.advanced.emulator.launcher/media/p_pixel/,.png]</texture>
                 <aspectratio>keep</aspectratio>
+            </control>
+        </definition>
+    </include>
+    <include name="View_540_ROM_Details">
+        <param name="left" default="0" />
+        <param name="right" default="120" />
+        <definition>
+            <control type="label">
+                <left>$PARAM[left]</left>
+                <right>$PARAM[right]</right>
+                <height>40</height>
+                <aligny>top</aligny>
+                <label>$VAR[ROM_Details]</label>
+                <textcolor>$VAR[ColorHighlight]</textcolor>
+                <font>font_small</font>
             </control>
         </definition>
     </include>
@@ -93,15 +108,7 @@
                     <label>$INFO[ListItem.Label]</label>
                 </control>
                 <!-- Info Line -->
-                <control type="label">
-                    <left>0</left>
-                    <right>120</right>
-                    <height>40</height>
-                    <aligny>top</aligny>
-                    <label>$VAR[ROM_Details]</label>
-                    <textcolor>$VAR[ColorHighlight]</textcolor>
-                    <font>font_small</font>
-                </control>
+                <include>View_540_ROM_Details</include>
                 <control type="group">
                     <top>20</top>
                     <height>265</height>

--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,4 @@
-<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.57-alpha1">
+<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.58-alpha1">
     <requires>
         <import addon="xbmc.gui" version="5.14.0" />
         <import addon="script.skinshortcuts" version="0.4.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+0.9.58
+- Fix Icon Wall View to remove stretch for Advanced Emulator Launcher
+- Add Platform Icon and ROM Details for Advanced Emulator Launcher
+
 0.9.57
 - Fix vertical scrollbar for Advanced Emulator Launcher views and remove duplicate clearlogo
 


### PR DESCRIPTION
Updating views for Advanced Emulator Launcher so that they have the platform Icon and ROM details listed instead of just the year.
The only views without the platform icon are the list views because I honestly have no idea where to put them.

![infowall2](https://user-images.githubusercontent.com/2657771/73489976-93eb5a00-4379-11ea-8dff-0f59e0d31007.png)
![infowall](https://user-images.githubusercontent.com/2657771/73489986-95b51d80-4379-11ea-80c9-2af5d650ceef.png)
![mediaInfo](https://user-images.githubusercontent.com/2657771/73489987-96e64a80-4379-11ea-8204-a34fefaa972e.png)
![tripanel](https://user-images.githubusercontent.com/2657771/73489991-98b00e00-4379-11ea-9a11-057774e91660.png)
