### PR TITLE
UPDATE 3: Add ratings to Info Wall, new plan

### DIFF
--- a/1080i/Includes_View_50_List.xml
+++ b/1080i/Includes_View_50_List.xml
@@ -65,6 +65,7 @@
                 <param name="icon" value="$VAR[Image_Landscape]" />
                 <param name="title" value="$VAR[Label_List_Title]" />
                 <param name="plot" value="$INFO[ListItem.Plot]" />
+                <param name="ratings" value="false" />
             </include>
         </control>
     </include>
@@ -384,6 +385,12 @@
                             <param name="nextaired" value="false" />
                         </include>
                         <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                        <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
+                            <param name="top" value="-10" />
+                            <param name="imdbvotes" value="false" />
+                            <param name="top250" value="false" />
+                            <param name="oscars" value="false" />
+                        </include>
                         <control type="textbox">
                             <top>25</top>
                             <font>font_plotbox</font>

--- a/1080i/Includes_View_50_List.xml
+++ b/1080i/Includes_View_50_List.xml
@@ -385,12 +385,6 @@
                             <param name="nextaired" value="false" />
                         </include>
                         <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
-                        <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
-                            <param name="top" value="-10" />
-                            <param name="imdbvotes" value="false" />
-                            <param name="top250" value="false" />
-                            <param name="oscars" value="false" />
-                        </include>
                         <control type="textbox">
                             <top>25</top>
                             <font>font_plotbox</font>
@@ -466,12 +460,23 @@
                         <param name="oscars" value="false" />
                     </include>
                     <control type="textbox">
+                        <visible>!$EXP[Exp_IsPluginAdvancedLauncher]</visible>
                         <top>25</top>
                         <font>font_plotbox</font>
                         <textcolor>main_fg_70</textcolor>
                         <align>left</align>
                         <aligny>top</aligny>
                         <height>160</height>
+                        <label>$VAR[Label_Plot]</label>
+                    </control>
+                    <control type="textbox">
+                        <visible>$EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                        <top>25</top>
+                        <font>font_plotbox</font>
+                        <textcolor>main_fg_70</textcolor>
+                        <align>left</align>
+                        <aligny>top</aligny>
+                        <height>208</height>
                         <label>$VAR[Label_Plot]</label>
                     </control>
                 </control>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -123,7 +123,7 @@
                         <itemgap>0</itemgap>
                         <control type="label">
                             <font>font_title_small</font>
-                            <top>-8</top>
+                            <top>0</top>
                             <textcolor>main_fg_100</textcolor>
                             <align>left</align>
                             <aligny>top</aligny>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -115,7 +115,7 @@
                         <param name="right" value="30" />
                     </include>
                     <control type="grouplist">
-                        <top>451.435</top>
+                        <top>440.435</top>
                         <left>0</left>
                         <right>30</right>
                         <orientation>vertical</orientation>
@@ -123,7 +123,7 @@
                         <itemgap>0</itemgap>
                         <control type="label">
                             <font>font_title_small</font>
-                            <top>-12</top>
+                            <top>-8</top>
                             <textcolor>main_fg_100</textcolor>
                             <align>left</align>
                             <aligny>top</aligny>
@@ -142,13 +142,13 @@
                             <param name="container" value="Container($PARAM[id])." />
                         </include>
                         <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher] + $PARAM[ratings]">
-                            <param name="top" value="-30" />
+                            <param name="top" value="-15" />
                             <param name="imdbvotes" value="false" />
                             <param name="top250" value="false" />
                             <param name="oscars" value="false" />
                         </include>
                         <control type="textbox">
-                            <top>25</top>
+                            <top>28</top>
                             <font>font_plotbox</font>
                             <textcolor>main_fg_70</textcolor>
                             <align>left</align>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -123,6 +123,7 @@
                         <itemgap>0</itemgap>
                         <control type="label">
                             <font>font_title_small</font>
+                            <top>-12</top>
                             <textcolor>main_fg_100</textcolor>
                             <align>left</align>
                             <aligny>top</aligny>
@@ -141,18 +142,18 @@
                             <param name="container" value="Container($PARAM[id])." />
                         </include>
                         <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher] + $PARAM[ratings]">
-                            <param name="top" value="-10" />
+                            <param name="top" value="-30" />
                             <param name="imdbvotes" value="false" />
                             <param name="top250" value="false" />
                             <param name="oscars" value="false" />
                         </include>
                         <control type="textbox">
-                            <top>20</top>
+                            <top>25</top>
                             <font>font_plotbox</font>
                             <textcolor>main_fg_70</textcolor>
                             <align>left</align>
                             <aligny>top</aligny>
-                            <height>200</height>
+                            <height>163</height>
                             <label>$PARAM[plot]</label>
                         </control>
                     </control>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -85,6 +85,7 @@
 
     <include name="View_522_Showcase_Seasons_Info">
         <param name="seasons" default="true" />
+        <param name="ratings" default="true" />>
         <param name="id" default="5229" />
         <definition>
             <control type="group">
@@ -139,8 +140,14 @@
                             <param name="label" value="$INFO[Container($PARAM[id]).ListItem.MPAA]" />
                             <param name="container" value="Container($PARAM[id])." />
                         </include>
+                        <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher] + $PARAM[ratings]">
+                            <param name="top" value="-10" />
+                            <param name="imdbvotes" value="false" />
+                            <param name="top250" value="false" />
+                            <param name="oscars" value="false" />
+                        </include>
                         <control type="textbox">
-                            <top>25</top>
+                            <top>20</top>
                             <font>font_plotbox</font>
                             <textcolor>main_fg_70</textcolor>
                             <align>left</align>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -111,7 +111,7 @@
                 <control type="group">
                     <include content="View_540_Platform_Icon">
                         <param name="top" value="440" />
-                        <param name="right" value="30" />>
+                        <param name="right" value="30" />
                     </include>
                     <control type="grouplist">
                         <top>451.435</top>

--- a/1080i/Includes_View_53_Poster.xml
+++ b/1080i/Includes_View_53_Poster.xml
@@ -19,7 +19,7 @@
                     <usecontrolcoords>true</usecontrolcoords>
                     <itemgap>0</itemgap>
                     <control type="label">
-                        <label>$VAR[Label_List_Title]</label>>
+                        <label>$VAR[Label_List_Title]</label>
                         <height>60</height>
                         <aligny>top</aligny>
                         <textcolor>main_fg_100</textcolor>

--- a/1080i/Includes_View_53_Poster.xml
+++ b/1080i/Includes_View_53_Poster.xml
@@ -27,6 +27,12 @@
                     </control>
                     <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
                     <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                    <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
+                        <param name="top" value="-10" />
+                        <param name="imdbvotes" value="false" />
+                        <param name="top250" value="false" />
+                        <param name="oscars" value="false" />
+                    </include>
                     <control type="textbox">
                         <top>20</top>
                         <label fallback="19055">$VAR[Label_Plot]</label>

--- a/1080i/Includes_View_53_Poster.xml
+++ b/1080i/Includes_View_53_Poster.xml
@@ -20,6 +20,7 @@
                     <itemgap>0</itemgap>
                     <control type="label">
                         <label>$VAR[Label_List_Title]</label>
+                        <top>-12</top>
                         <height>60</height>
                         <aligny>top</aligny>
                         <textcolor>main_fg_100</textcolor>
@@ -28,7 +29,7 @@
                     <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
                     <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
                     <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
-                        <param name="top" value="-10" />
+                        <param name="top" value="-30" />
                         <param name="imdbvotes" value="false" />
                         <param name="top250" value="false" />
                         <param name="oscars" value="false" />

--- a/1080i/Includes_View_53_Poster.xml
+++ b/1080i/Includes_View_53_Poster.xml
@@ -20,7 +20,6 @@
                     <itemgap>0</itemgap>
                     <control type="label">
                         <label>$VAR[Label_List_Title]</label>
-                        <top>-12</top>
                         <height>60</height>
                         <aligny>top</aligny>
                         <textcolor>main_fg_100</textcolor>
@@ -28,12 +27,6 @@
                     </control>
                     <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
                     <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
-                    <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
-                        <param name="top" value="-30" />
-                        <param name="imdbvotes" value="false" />
-                        <param name="top250" value="false" />
-                        <param name="oscars" value="false" />
-                    </include>
                     <control type="textbox">
                         <top>20</top>
                         <label fallback="19055">$VAR[Label_Plot]</label>

--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,4 @@
-<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.58-alpha1">
+<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.59-alpha1">
     <requires>
         <import addon="xbmc.gui" version="5.14.0" />
         <import addon="script.skinshortcuts" version="0.4.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.9.59
+- Add ratings (imdb, metacritc, rotten tomatoes) to Info Wall, Tri-Panel and Poster views
+
 0.9.58
 - Fix Icon Wall View to remove stretch for Advanced Emulator Launcher
 - Add Platform Icon and ROM Details for Advanced Emulator Launcher

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 0.9.59
-- Add ratings (imdb, metacritc, rotten tomatoes) to Info Wall, Tri-Panel and Poster views
+- Add ratings (imdb, metacritc, rotten tomatoes) to Info Wall view.
 
 0.9.58
 - Fix Icon Wall View to remove stretch for Advanced Emulator Launcher


### PR DESCRIPTION
Added the imdb, metacritic, rotten tomatoes, etc. ratings to the `Info Wall, Tri-Panel` and `Poster` Views. Added a param to keep the ratings **off** `Media Info` since `Media Info 2` has that information.

Before:
![before](https://user-images.githubusercontent.com/2657771/74117854-05e84e00-4b87-11ea-999a-d20b7515b649.png)

After:
![after](https://user-images.githubusercontent.com/2657771/74117860-0bde2f00-4b87-11ea-87b1-0eeb4ea08f36.png)
![after2](https://user-images.githubusercontent.com/2657771/74117861-0e408900-4b87-11ea-86e3-471f0151cd8c.png)
![after3](https://user-images.githubusercontent.com/2657771/74117870-14366a00-4b87-11ea-915d-d4ca30a897ac.png)

