### PR TITLE
Update 2: Add Info Wall 2 Video View

### DIFF
--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -2523,7 +2523,7 @@
 
     <include name="Object_Scrollbars">
         <include content="Object_Scrollbar_Vert">
-            <param name="visible" value="Control.IsVisible(50) | Control.IsVisible(500) | Control.IsVisible(501) | Control.IsVisible(502) | Control.IsVisible(503) | Control.IsVisible(504) | Control.IsVisible(51) | Control.IsVisible(510) | Control.IsVisible(511) | Control.IsVisible(512) | Control.IsVisible(513) | Control.IsVisible(514) | Control.IsVisible(515) | Control.IsVisible(540)" />  
+            <param name="visible" value="Control.IsVisible(50) | Control.IsVisible(500) | Control.IsVisible(501) | Control.IsVisible(502) | Control.IsVisible(503) | Control.IsVisible(504) | Control.IsVisible(51) | Control.IsVisible(510) | Control.IsVisible(511) | Control.IsVisible(512) | Control.IsVisible(513) | Control.IsVisible(514) | Control.IsVisible(515) | Control.IsVisible(540) | Control.IsVisible(516)" />  
         </include>
         <include content="Object_Scrollbar_Horz">
             <param name="visible" value="Control.IsVisible(52) | Control.IsVisible(520) | Control.IsVisible(521) | Control.IsVisible(522) | Control.IsVisible(523) | Control.IsVisible(53)" />

--- a/1080i/Includes_View_50_List.xml
+++ b/1080i/Includes_View_50_List.xml
@@ -459,12 +459,23 @@
                         <param name="oscars" value="false" />
                     </include>
                     <control type="textbox">
+                        <visible>!$EXP[Exp_IsPluginAdvancedLauncher]</visible>
                         <top>25</top>
                         <font>font_plotbox</font>
                         <textcolor>main_fg_70</textcolor>
                         <align>left</align>
                         <aligny>top</aligny>
                         <height>160</height>
+                        <label>$VAR[Label_Plot]</label>
+                    </control>
+                    <control type="textbox">
+                        <visible>$EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                        <top>25</top>
+                        <font>font_plotbox</font>
+                        <textcolor>main_fg_70</textcolor>
+                        <align>left</align>
+                        <aligny>top</aligny>
+                        <height>208</height>
                         <label>$VAR[Label_Plot]</label>
                     </control>
                 </control>

--- a/1080i/Includes_View_51_Wall.xml
+++ b/1080i/Includes_View_51_Wall.xml
@@ -567,6 +567,31 @@
         </control>
     </include>
 
+    <include name="View_516_Wall_Info_2">
+        <control type="group">
+            <include>View_Group</include>
+            <visible>Control.IsVisible(516)</visible>
+            <include content="View_51_Wall_Container">
+                <param name="id" value="516" />
+                <param name="height" value="view_height" />
+                <param name="viewtype" value="$LOCALIZE[31436]" />
+                <param name="viewtypename" value="icon" />
+                <param name="controllayout" value="View_514_Wall_Info_Layout" />
+                <param name="forced" value="true" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | !$EXP[Exp_IsPluginAdvancedLauncher]" />
+                <width>1028.56</width>
+                <include>View_Vertical_Movement</include>
+            </include>
+            <include content="View_522_Showcase_Seasons_Info">
+                <param name="visible" value="true" />
+                <param name="icon" value="$VAR[Image_Landscape]" />
+                <param name="title" value="$VAR[Label_List_Title]" />
+                <param name="plot" value="$INFO[ListItem.Plot]" />
+                <param name="isView2" value="true" />>
+            </include>
+        </control>
+    </include>
+
     <include name="View_515_Wall_Landscape_Small">
         <control type="group">
             <include>View_Group</include>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -168,10 +168,20 @@
                                 <param name="name" value="Director" />
                                 <param name="label" value="ListItem.Director" />
                             </include>
-                            <include content="Object_Info_TextPairs">
-                                <param name="name" value="Tagline" />
-                                <param name="label" value="ListItem.Tagline" />
-                            </include>
+                            <control type="group">
+                                <visible>!String.isEmpty(ListItem.Tagline)</visible>
+                                <include content="Object_Info_TextPairs">
+                                    <param name="name" value="Tagline" />
+                                    <param name="label" value="ListItem.Tagline" />
+                                </include>
+                            </control>
+                            <control type="group">
+                                <visible>String.isEmpty(ListItem.Tagline)</visible>
+                                <include content="Object_Info_TextPairs">
+                                    <param name="name" value="Premiered" />
+                                    <param name="label" value="ListItem.Premiered" />
+                                </include>
+                            </control>
                         </control>
                     </control>
                 </control>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -86,6 +86,7 @@
     <include name="View_522_Showcase_Seasons_Info">
         <param name="seasons" default="true" />
         <param name="id" default="5229" />
+        <param name="isView2" default="false" />
         <definition>
             <control type="group">
                 <include>View_FlipSides</include>
@@ -139,7 +140,14 @@
                             <param name="label" value="$INFO[Container($PARAM[id]).ListItem.MPAA]" />
                             <param name="container" value="Container($PARAM[id])." />
                         </include>
+                        <include content="Object_Info_Ratings" condition="$PARAM[isView2]">
+                            <param name="top" value="-15" />
+                            <param name="imdbvotes" value="false" />
+                            <param name="top250" value="false" />
+                            <param name="oscars" value="false" />
+                        </include>
                         <control type="textbox">
+                            <visible>!$PARAM[isView2]</visible>
                             <top>25</top>
                             <font>font_plotbox</font>
                             <textcolor>main_fg_70</textcolor>
@@ -147,6 +155,23 @@
                             <aligny>top</aligny>
                             <height>200</height>
                             <label>$PARAM[plot]</label>
+                        </control>
+                        <control type="grouplist">
+                            <visible>$PARAM[isView2]</visible>
+                            <top>25</top>
+                            <itemgap>14</itemgap>
+                            <include content="Object_Info_TextPairs">
+                                <param name="name" value="Genre" />
+                                <param name="label" value="ListItem.Genre" />
+                            </include>
+                            <include content="Object_Info_TextPairs">
+                                <param name="name" value="Director" />
+                                <param name="label" value="ListItem.Director" />
+                            </include>
+                            <include content="Object_Info_TextPairs">
+                                <param name="name" value="Tagline" />
+                                <param name="label" value="ListItem.Tagline" />
+                            </include>
                         </control>
                     </control>
                 </control>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -3,7 +3,7 @@
 <window id="6">
     <defaultcontrol always="true">50</defaultcontrol>
     <menucontrol>300</menucontrol>
-    <views>50,500,501,502,504,503,51,510,511,512,513,514,515,52,520,521,522,524,53,523</views>
+    <views>50,500,501,502,504,503,51,510,511,512,513,514,516,515,52,520,521,522,524,53,523</views>
     <onload condition="System.HasAddon(script.tv.show.next.aired)">RunScript(script.tv.show.next.aired,backend=True)</onload>
     <controls>
         <include>Global_Background</include>
@@ -25,6 +25,7 @@
             <include>View_513_Wall_Circle</include>
             <include>View_514_Wall_Info</include>
             <include>View_515_Wall_Landscape_Small</include>
+            <include>View_516_Wall_Info_2</include>
             <include>View_52_Showcase</include>
             <include>View_520_Showcase_Square</include>
             <include>View_521_Showcase_Landscape</include>

--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,4 @@
-<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.58-alpha1">
+<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.59-alpha1">
     <requires>
         <import addon="xbmc.gui" version="5.14.0" />
         <import addon="script.skinshortcuts" version="0.4.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.9.59
+ - Add Video View 'Info Wall 2'
+
 0.9.58
 - Fix Icon Wall View to remove stretch for Advanced Emulator Launcher
 - Add Platform Icon and ROM Details for Advanced Emulator Launcher

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1481,3 +1481,8 @@ msgstr "Clearart with seekbar"
 msgctxt "#31435"
 msgid "ROM Trailer"
 msgstr ""
+
+#: /1080i/Includes_View_51_Wall.xml
+msgctxt "#31436"
+msgid "Info Wall 2"
+msgstr ""


### PR DESCRIPTION
New view shows the metacritic, rottentomatoes ratings along with metadata about genre, tagline, director instead of plot details.
Spacing should be consistent with details view. 

![after1](https://user-images.githubusercontent.com/2657771/75634252-026e4280-5bda-11ea-9def-afc01b4b9042.png)
![after2](https://user-images.githubusercontent.com/2657771/75634253-04d09c80-5bda-11ea-9795-4cd73bb51342.png)
