### PR TITLE
New ROM Info Wall Trailer View

### DIFF
--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -2523,7 +2523,7 @@
 
     <include name="Object_Scrollbars">
         <include content="Object_Scrollbar_Vert">
-            <param name="visible" value="Control.IsVisible(50) | Control.IsVisible(500) | Control.IsVisible(501) | Control.IsVisible(502) | Control.IsVisible(503) | Control.IsVisible(504) | Control.IsVisible(51) | Control.IsVisible(510) | Control.IsVisible(511) | Control.IsVisible(512) | Control.IsVisible(513) | Control.IsVisible(514) | Control.IsVisible(515) | Control.IsVisible(540) | Control.IsVisible(516)" />  
+            <param name="visible" value="Control.IsVisible(50) | Control.IsVisible(500) | Control.IsVisible(501) | Control.IsVisible(502) | Control.IsVisible(503) | Control.IsVisible(504) | Control.IsVisible(51) | Control.IsVisible(510) | Control.IsVisible(511) | Control.IsVisible(512) | Control.IsVisible(513) | Control.IsVisible(514) | Control.IsVisible(515) | Control.IsVisible(540) | Control.IsVisible(516) | Control.IsVisible(541)" />  
         </include>
         <include content="Object_Scrollbar_Horz">
             <param name="visible" value="Control.IsVisible(52) | Control.IsVisible(520) | Control.IsVisible(521) | Control.IsVisible(522) | Control.IsVisible(523) | Control.IsVisible(53)" />

--- a/1080i/Includes_View_51_Wall.xml
+++ b/1080i/Includes_View_51_Wall.xml
@@ -388,6 +388,7 @@
         <param name="circle" default="false" />
         <param name="diffuse" default="diffuse/poster-wall.png" />
         <param name="altid" default="999999" />
+        <param name="focustrailer" default="false" />
         <definition>
             <control type="$PARAM[controltype]" id="$PARAM[id]">
                 <nested />
@@ -431,6 +432,7 @@
                         <param name="label2" value="$PARAM[label2]" />
                         <param name="colordiffuse" value="$PARAM[colordiffuse_fo]" />
                     </include>
+                    <include condition="$PARAM[focustrailer]">View_540_Button_Include</include>
                 </focusedlayout>
             </control>
         </definition>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -87,18 +87,25 @@
         <param name="seasons" default="true" />
         <param name="id" default="5229" />
         <param name="isView2" default="false" />
+        <param name="isRomTrailer" default="false" />
         <definition>
             <control type="group">
                 <include>View_FlipSides</include>
                 <top>0</top>
                 <width>761.44</width>
                 <visible>$PARAM[visible]</visible>
-                <include content="View_50_Poster">
+                <include content="View_50_Poster" condition="!$PARAM[isRomTrailer]">
                     <param name="height" value="441.435" />
                     <param name="width" value="761.44" />
                     <param name="icon" value="$PARAM[icon]" />
                     <param name="diffuse" value="diffuse/landscape-info.png" />
                     <param name="iconvisible" value="$PARAM[iconvisible]" />
+                </include>
+                <include content="View_540_Poster" condition="$PARAM[isRomTrailer]">
+                    <param name="height" value="441.435" />
+                    <param name="width" value="761.44" />
+                    <param name="icon" value="$PARAM[icon]" />
+                    <param name="diffuse" value="diffuse/landscape-info.png" />
                 </include>
                 <control type="image">
                     <top>0</top>
@@ -107,7 +114,7 @@
                     <height>390</height>
                     <texture background="true">$VAR[Image_ClearLogo]</texture>
                     <aspectratio align="right" aligny="bottom">keep</aspectratio>
-                    <visible>[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
+                    <visible>!$EXP[Exp_IsPluginAdvancedLauncher] + [!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
                 </control>
                 <control type="group">
                     <include content="View_540_Platform_Icon">

--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -192,6 +192,7 @@
                 <param name="forced" value="true" />
                 <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]" />
                 <param name="focustrailer" value="true" />
+                <param name="aspectratio" value="keep" />
                 <width>1028.56</width>
                 <include>View_Vertical_Movement</include>
             </include>

--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -41,32 +41,22 @@
             <texturefocus>-</texturefocus>
             <texturenofocus>-</texturenofocus>
             <animation type="Focus">
-                <effect type="fade" delay="2000" start="0" end="100" />
+                <effect type="fade" delay="3500" start="0" end="100" />
             </animation>
         </control>
     </include>
-    <include name="View_540_List_Info">
-        <control type="group">
-            <include>View_FlipSides</include>
-            <width>1028.53</width>
-            <control type="group">
-                <width>295.2</width>
-                <height>420</height>
-                <control type="image">
-                    <bottom>30</bottom>
-                    <right>30</right>
-                    <texture background="true">$VAR[ROM_Simple_Art_Main]</texture>
-                    <aspectratio>keep</aspectratio>
-                </control>
-            </control>
+    <include name="View_540_Poster">
+        <param name="height" default="view_poster_height" />
+        <param name="width" default="view_poster_width" />
+        <definition>
             <control type="group">
                 <right>0</right>
-                <width>723.33</width>
-                <height>420</height>
+                <width>$PARAM[width]</width>
+                <height>$PARAM[height]</height>
                 <!-- Backing Panel -->
                 <include content="View_50_Poster">
-                    <param name="height" value="420" />
-                    <param name="width" value="723.33" />
+                    <param name="height" value="$PARAM[height]" />
+                    <param name="width" value="$PARAM[width]" />
                     <param name="icon" value="[Player.Playing + !IsEmpty(ListItem.Trailer)] | !String.IsEmpty(ListItem.Art(snap))" />
                     <param name="diffuse" value="diffuse/landscape-mediainfo.png" />
                 </include>
@@ -87,6 +77,26 @@
                     </control>
                 </control>
             </control>
+        </definition>
+    </include>
+    <include name="View_540_List_Info">
+        <control type="group">
+            <include>View_FlipSides</include>
+            <width>1028.53</width>
+            <control type="group">
+                <width>295.2</width>
+                <height>420</height>
+                <control type="image">
+                    <bottom>30</bottom>
+                    <right>30</right>
+                    <texture background="true">$VAR[ROM_Simple_Art_Main]</texture>
+                    <aspectratio>keep</aspectratio>
+                </control>
+            </control>
+            <include content="View_540_Poster">
+                <param name="height" value="420" />
+                <param name="width" value="723.33" />
+            </include>
             <control type="grouplist">
                 <top>430</top>
                 <left>0</left>
@@ -149,6 +159,7 @@
         </control>
     </include>
 
+    <!-- Views -->
     <include name="View_540_List_ROM_Info">
         <control type="group">
             <visible>Control.IsVisible(540)</visible>
@@ -165,6 +176,32 @@
                 <param name="visible" value="$EXP[Exp_IsPluginAdvancedLauncher]" />
             </include>
             <include>View_540_List_Info</include>
+        </control>
+    </include>
+
+    <include name="View_541_Wall_Info">
+        <control type="group">
+            <include>View_Group</include>
+            <visible>Control.IsVisible(541)</visible>
+            <include content="View_51_Wall_Container">
+                <param name="id" value="541" />
+                <param name="height" value="view_height" />
+                <param name="viewtype" value="$LOCALIZE[31437]" />
+                <param name="viewtypename" value="icon" />
+                <param name="controllayout" value="View_514_Wall_Info_Layout" />
+                <param name="forced" value="true" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="focustrailer" value="true" />
+                <width>1028.56</width>
+                <include>View_Vertical_Movement</include>
+            </include>
+            <include content="View_522_Showcase_Seasons_Info">
+                <param name="visible" value="true" />
+                <param name="icon" value="$VAR[Image_Landscape]" />
+                <param name="title" value="$VAR[Label_List_Title]" />
+                <param name="plot" value="$INFO[ListItem.Plot]" />
+                <param name="isRomTrailer" value="true" />
+            </include>
         </control>
     </include>
 </includes>

--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -190,7 +190,7 @@
                 <param name="viewtypename" value="icon" />
                 <param name="controllayout" value="View_514_Wall_Info_Layout" />
                 <param name="forced" value="true" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="$EXP[Exp_IsPluginAdvancedLauncher]" />
                 <param name="focustrailer" value="true" />
                 <param name="aspectratio" value="keep" />
                 <width>1028.56</width>

--- a/1080i/MyPrograms.xml
+++ b/1080i/MyPrograms.xml
@@ -4,7 +4,7 @@
     <defaultcontrol always="true">50</defaultcontrol>
     <menucontrol>300</menucontrol>
     
-    <views>50,500,501,502,504,503,51,510,511,512,513,514,515,52,520,521,522,524,53,523,540</views>
+    <views>50,500,501,502,504,503,51,510,511,512,513,514,515,52,520,521,522,524,53,523,540,541</views>
     
     <controls>
         <include>Global_Background</include>
@@ -33,7 +33,7 @@
             <include>View_524_Showcase_Seasons</include>
             <include>View_53_Poster</include>
             <include>View_540_List_ROM_Info</include>
-
+            <include>View_541_Wall_Info</include>
             <include>Object_Scrollbars</include>
         </control>
         

--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,4 @@
-<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.61">
+<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.62">
     <requires>
         <import addon="xbmc.gui" version="5.14.0" />
         <import addon="script.skinshortcuts" version="0.4.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.9.62
+ - Add Video View 'ROM Info Wall Trailer'
+
 0.9.59
  - Add Video View 'Info Wall 2'
 

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1477,7 +1477,7 @@ msgctxt "#31434"
 msgid "Clearart with seekbar"
 msgstr "Clearart with seekbar"
 
-#: /1080i/Includes_View_54_ROM_Simple.xml
+#: /1080i/Includes_View_54_AEL.xml
 msgctxt "#31435"
 msgid "ROM Trailer"
 msgstr ""
@@ -1485,4 +1485,9 @@ msgstr ""
 #: /1080i/Includes_View_51_Wall.xml
 msgctxt "#31436"
 msgid "Info Wall 2"
+msgstr ""
+
+#: /1080i/Includes_View_54_AEL.xml
+msgctxt "#31437"
+msgid "ROM Info Wall Trailer"
 msgstr ""


### PR DESCRIPTION
Adding a new Trailer view for Advanced Emulator Launcher. Based on the Info Wall view but separate code due to `keep` aspect ratio and shared snap/trailer logic with the original trailer view. Included some screenshots and video in action.
![new-view1](https://user-images.githubusercontent.com/2657771/82277189-42c99b00-9955-11ea-8b6d-1238910e5363.png)
![new-view2](https://user-images.githubusercontent.com/2657771/82277191-43623180-9955-11ea-8890-58ba34c78636.png)

https://youtu.be/-2856GSbxcg