### PR TITLE
Fix double countdown in Up Next labels.

### DIFF
--- a/1080i/script-upnext-stillwatching-simple.xml
+++ b/1080i/script-upnext-stillwatching-simple.xml
@@ -36,7 +36,7 @@
                     <include content="Object_IconicButton">
                         <param name="id" value="11" />
                         <param name="groupid" value="9011" />
-                        <param name="label" value="$ADDON[service.upnext 30035] [COLOR $VAR[ColorHighlight]]$INFO[Player.TimeRemaining(ss),,][/COLOR]" />
+                        <param name="label" value="$ADDON[service.upnext 30035]" />
                         <param name="icon" value="special://skin/extras/icons/play3.png" />
                         <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,59)" />
                         <onclick>SendClick(3012)</onclick>

--- a/1080i/script-upnext-stillwatching-simple.xml
+++ b/1080i/script-upnext-stillwatching-simple.xml
@@ -52,7 +52,8 @@
 
             </control>
         </control>
-
-        
+        <control type="progress" id="3014">
+            <visible>false</visible>
+        </control>
     </controls>
 </window>

--- a/1080i/script-upnext-stillwatching.xml
+++ b/1080i/script-upnext-stillwatching.xml
@@ -107,7 +107,7 @@
                         <include content="Object_IconicButton">
                             <param name="id" value="11" />
                             <param name="groupid" value="9011" />
-                            <param name="label" value="$ADDON[service.upnext 30035] [COLOR $VAR[ColorHighlight]]$INFO[Player.TimeRemaining(ss),,][/COLOR]" />
+                            <param name="label" value="$ADDON[service.upnext 30035]" />
                             <param name="icon" value="special://skin/extras/icons/play3.png" />
                             <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,59)" />
                             <onclick>SendClick(3012)</onclick>

--- a/1080i/script-upnext-upnext-simple.xml
+++ b/1080i/script-upnext-upnext-simple.xml
@@ -52,7 +52,8 @@
 
             </control>
         </control>
-
-        
+        <control type="progress" id="3014">
+            <visible>false</visible>
+        </control>
     </controls>
 </window>

--- a/1080i/script-upnext-upnext-simple.xml
+++ b/1080i/script-upnext-upnext-simple.xml
@@ -36,7 +36,7 @@
                     <include content="Object_IconicButton">
                         <param name="id" value="11" />
                         <param name="groupid" value="9011" />
-                        <param name="label" value="$ADDON[service.upnext 30037] [COLOR $VAR[ColorHighlight]]$INFO[Player.TimeRemaining(ss),,][/COLOR]..." />
+                        <param name="label" value="$ADDON[service.upnext 30037]" />
                         <param name="icon" value="special://skin/extras/icons/play3.png" />
                         <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,59)" />
                         <onclick>SendClick(3012)</onclick>

--- a/1080i/script-upnext-upnext.xml
+++ b/1080i/script-upnext-upnext.xml
@@ -43,14 +43,14 @@
                     <control type="label">
                         <height>30</height>
                         <font>font_title_small</font>
-                        <label>$ADDON[service.upnext 30037] [COLOR $VAR[ColorHighlight]]$INFO[Player.TimeRemaining(ss),,][/COLOR]...</label>
+                        <label>$ADDON[service.upnext 30037]</label>
                         <textcolor>panel_fg_100</textcolor>
                         <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                     </control>
                     <control type="label">
                         <height>30</height>
                         <font>font_title_small</font>
-                        <label>$ADDON[service.upnext 30008]...</label>
+                        <label>$ADDON[service.upnext 30008]</label>
                         <textcolor>panel_fg_100</textcolor>
                         <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                     </control>


### PR DESCRIPTION
The Up Next dialogs still have double countdowns. This has been reported in #178 and partially fixed in #179.

I also fixed the Up Next Simple dialogs that had a missing `3014` control. The code of Up Next requires them to be in the skin.

These are the translations as defined in Up Next:
```
msgctxt "#30035"
msgid "Continue watching in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
msgstr ""

msgctxt "#30036"
msgid "Up next in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
msgstr ""

msgctxt "#30037"
msgid "Next episode in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
msgstr ""
```