### PR TITLE
AEL Fix

### DIFF
--- a/1080i/Includes_AEL.xml
+++ b/1080i/Includes_AEL.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <includes>
     <variable name="ROM_Simple_Art_Main">
-        <value condition="!String.IsEqual(ListItem.Property(platform),MAME) + !String.IsEmpty(ListItem.Art(3dbox))">$INFO[ListItem.Art(3dbox)]</value>
-        <value condition="!String.IsEqual(ListItem.Property(platform),MAME) + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
-        <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(flyer))">$INFO[ListItem.Art(flyer)]</value>
-        <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
-    </variable>
-    <variable name="ROM_Simple_Art_Main_2D">
         <value condition="!String.IsEqual(ListItem.Property(platform),MAME) + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>
         <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(flyer))">$INFO[ListItem.Art(flyer)]</value>
         <value condition="String.IsEqual(ListItem.Property(platform),MAME)  + !String.IsEmpty(ListItem.Art(boxfront))">$INFO[ListItem.Art(boxfront)]</value>

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -179,7 +179,7 @@
     <variable name="Image_Poster">
         <value condition="Skin.HasSetting(SkinHelper.EnableAnimatedPosters) + !String.IsEmpty(ListItem.Art(animatedposter))">$INFO[ListItem.Art(animatedposter)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(season.poster)) + !Window.IsVisible(Home)">$INFO[ListItem.Art(season.poster)]</value>
-        <value condition="$EXP[Exp_IsPluginAdvancedLauncher]">$VAR[ROM_Simple_Art_Main_2D]</value>
+        <value condition="$EXP[Exp_IsPluginAdvancedLauncher]">$VAR[ROM_Simple_Art_Main]</value>
         <value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(tvshow.poster)]</value>
         <value>$INFO[ListItem.Icon]</value>

--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,4 @@
-<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.62">
+<addon id="skin.arctic.zephyr.2" name="Arctic Zephyr 2" provider-name="jurialmunkey" version="0.9.62.1">
     <requires>
         <import addon="xbmc.gui" version="5.14.0" />
         <import addon="script.skinshortcuts" version="0.4.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.9.62.1
+ - Fix for AEL to remove Box3D rendering since the plugin does not support managing that asset anymore
+
 0.9.62
  - Add Video View 'ROM Info Wall Trailer'
 


### PR DESCRIPTION
Advanced Emulator Launcher does not provide an option to manage the Box3D asset anymore. Just removing.